### PR TITLE
dist: enable RW access to maddy database location

### DIFF
--- a/dist/systemd/maddy.service
+++ b/dist/systemd/maddy.service
@@ -25,6 +25,7 @@ RuntimeDirectory=maddy
 StateDirectory=maddy
 LogsDirectory=maddy
 ReadOnlyPaths=/usr/lib/maddy
+ReadWritePaths=/var/lib/maddy
 
 # Strict sandboxing. You have no reason to trust code written by strangers from GitHub.
 PrivateTmp=true


### PR DESCRIPTION
This change is based on my personal experience of setting up the server. The write check kept failing until i added this configuration bit. I do note that this might just be because i messed up the setup process and had to install it in somewhat non-standard way. Also my systemd version is <235 so that might be my issue. If this does turn out to be a older systemd specific problem, could this be documented as a some sort of a known issue? Anyway i see no way of implementing this in the other service file so i do not know how to go about to fix that there as well, without hard-coding the path.
```
$ systemd --version
systemd 232
+PAM +AUDIT +SELINUX +IMA +APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD +IDN

$ lsb_release -a
No LSB modules are available.
Distributor ID: Debian
Description:    Debian GNU/Linux 9.11 (stretch)
Release:        9.11
Codename:       stretch

$ uname -a
Linux machine 4.9.0-11-amd64 #1 SMP Debian 4.9.189-3 (2019-09-02) x86_64 GNU/Linux
```
