### PR TITLE
dist: Update fail2ban filter

### DIFF
--- a/dist/fail2ban/filter.d/maddy-auth.conf
+++ b/dist/fail2ban/filter.d/maddy-auth.conf
@@ -2,5 +2,5 @@
 before = common.conf
 
 [Definition]
-failregex    = (smtp|submission|lmtp|imap):\ authentication failed\t\{\"reason\":\".*\",\"src_ip\"\:\"<HOST>:\d+\"\,\"username\"\:\".*\"\}$
+failregex    = authentication failed\t\{\"reason\":\".*\",\"src_ip\"\:\"<HOST>:\d+\"\,\"username\"\:\".*\"\}$
 journalmatch = _SYSTEMD_UNIT=maddy.service + _COMM=maddy


### PR DESCRIPTION
Previously the fail2ban regex would only catch failed auth messages with a smtp/submission/lmtp/imap prefix.

This regex now also catches those without such a prefix.

I tested this on my maddy server where it worked well.