### PR TITLE
Added sudo check

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -508,6 +508,17 @@ EOF
 
 }
 
+# Checks if sudo is installed and sets the elevate variable for 
+# later use in the create_user and install_pkg functions
+check_if_sudo_is_installed() {
+    if sudo -n true
+    then
+      export elevate=1
+    else
+      export elevate=0
+    fi
+}
+
 run() {
     IFS=$'\n'
     read_config "$@"
@@ -530,7 +541,7 @@ run() {
     fi
 
     package
-    export elevate=1
+    check_if_sudo_is_installed
     create_user
     install_pkg
 


### PR DESCRIPTION
# Code

Earlier in the `run` function, there was this code fragment:

```
    export elevate=1
```

who always set the variable `elevate` to eq `1`, even if `sudo` is not installed on the user's system.

Let's not do this if user doesn't have `sudo` installed by adding more over-engineered code!

## Why

I noticed this when i was installing it on Debian, I didn't have `sudo` installed and I saw these things:

![bug-bug-bug image](https://user-images.githubusercontent.com/44648612/89146067-2cf76980-d585-11ea-968b-44821039a9c9.png)

I didn't realize right away that there was an error. But I realized I didn't have the `maddy` installed because of this