### PR TITLE
Update dovecot.md to correct typo

### DIFF
--- a/docs/third-party/dovecot.md
+++ b/docs/third-party/dovecot.md
@@ -50,7 +50,7 @@ service auth {
 Then just configure `dovecot_sasl` module for `submission`:
 ```
 submission ... {
-    auth dovecot_sasl unix:///var/run/dovecot/auth-client
+    auth dovecot_sasl unix:///var/run/dovecot/auth-maddy-client
     ... other configuration ...
 }
 ```


### PR DESCRIPTION
They should both be `auth-maddy-client`.