### PR TITLE
Update dovecot.md to avoid cyclic dependency

### DIFF
--- a/docs/third-party/dovecot.md
+++ b/docs/third-party/dovecot.md
@@ -17,7 +17,7 @@ protocols = imap lmtp
 
 # /etc/dovecot/conf.d/10-master.conf
 service lmtp {
- unix_listener /var/run/maddy/dovecot-lmtp.sock {
+ unix_listener lmtp-maddy {
    mode = 0600
    user = maddy
   }
@@ -27,7 +27,7 @@ service lmtp {
 Add `local_mailboxes` block to maddy config using `target.lmtp` module:
 ```
 target.lmtp local_mailboxes {
-    targets unix:///var/run/maddy/dovecot-lmtp.sock
+    targets unix:///var/run/dovecot/lmtp-maddy
 }
 ```
 


### PR DESCRIPTION
When I try to start Dovecot, it will complain if `/var/run/maddy/` is missing as it can't create /var/run/maddy/dovecot-lmtp.sock`.
When I try to start Maddy, it complains that `unix:///var/run/dovecot/auth-maddy-client` doesn't exist.

Therefore I can't start either service.
I decided to move the LMTP socket into Dovecot's runtime directory since it provides the socket,
and to remove the sock extension to match the naming convention in the rest of the directory.