### PR TITLE
Suggest disabling TLS for Dovecot LMTP unix socket

### DIFF
--- a/docs/third-party/dovecot.md
+++ b/docs/third-party/dovecot.md
@@ -28,6 +28,7 @@ Add `local_mailboxes` block to maddy config using `target.lmtp` module:
 ```
 target.lmtp local_mailboxes {
     targets unix:///var/run/maddy/dovecot-lmtp.sock
+    attempt_starttls no
 }
 ```
 


### PR DESCRIPTION
I don't see a point to TLS over a UNIX socket anyway, and it caused me trouble.