### PR TITLE
Patch Dockerfile for v0.4.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY . maddy/
 WORKDIR maddy/
 
 ENV LDFLAGS -static
-RUN apk --no-cache add bash git gcc musl-dev
+RUN apk --no-cache add bash git gcc musl-dev scdoc
 
 RUN mkdir /pkg/
 COPY maddy.conf /pkg/data/maddy.conf
@@ -12,10 +12,12 @@ COPY maddy.conf /pkg/data/maddy.conf
 RUN sed -Ei 's!\$\(hostname\) = .+!$(hostname) = {env:MADDY_HOSTNAME}!' /pkg/data/maddy.conf
 RUN sed -Ei 's!\$\(primary_domain\) = .+!$(primary_domain) = {env:MADDY_DOMAIN}!' /pkg/data/maddy.conf
 RUN sed -Ei 's!^tls .+!tls /data/tls_cert.pem /data/tls_key.pem!' /pkg/data/maddy.conf
+RUN sed -Ei 's!# state_dir /var/lib/maddy!state_dir /data!' /pkg/data/maddy.conf
+RUN sed -Ei 's!# runtime_dir /run/maddy!runtime_dir /tmp!' /pkg/data/maddy.conf
 
-RUN ./build.sh --builddir /tmp --destdir /pkg/ --configdir /data --statedir /data --runtimedir /tmp package install_pkg
+RUN ./build.sh --builddir /tmp --destdir /pkg/ build install
 
-FROM alpine:3.11
+FROM alpine:3.12
 LABEL maintainer="fox.cpp@disroot.org"
 
 RUN apk --no-cache add ca-certificates

--- a/maddy.conf
+++ b/maddy.conf
@@ -8,6 +8,12 @@
 # See manual pages (also available at https://foxcpp.dev/maddy) for reference
 # documentation.
 
+# Global directives
+# ----------------------------------------------------------------------------
+
+# state_dir /var/lib/maddy
+# runtime_dir /run/maddy
+
 # ----------------------------------------------------------------------------
 # Base variables
 


### PR DESCRIPTION
- Update stage 2 base image to `alpine:3.12` to match stage 1
- Use new syntax for `./build.sh`
- Patch the default `state_dir` and `runtime_dir` in the default `maddy.conf` so that it's backwards-compatible with v0.4.2.
  - This is not enough I think, I would still need to update my config file if I already wrote one (which I expect everyone to!)

Should I update the script so that it injects the old `state_dir` and `runtime_dir` in?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/foxcpp/maddy/320)
<!-- Reviewable:end -->
