### PR TITLE
config/tls: Fix tls_client parsing

### DIFF
--- a/framework/config/tls/client.go
+++ b/framework/config/tls/client.go
@@ -51,7 +51,7 @@ func TLSClientBlock(m *config.Map, node config.Node) (interface{}, error) {
 		return nil, nil
 	}, TLSCurvesDirective, &cfg.CurvePreferences)
 
-	if _, err := m.Process(); err != nil {
+	if _, err := childM.Process(); err != nil {
 		return nil, err
 	}
 
@@ -69,7 +69,7 @@ func TLSClientBlock(m *config.Map, node config.Node) (interface{}, error) {
 		cfg.RootCAs = pool
 	}
 
-	if certPath != "" || keyPath == "" {
+	if certPath != "" && keyPath != "" {
 		keypair, err := tls.LoadX509KeyPair(certPath, keyPath)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
`tls_client` recurses into processing itself and causes a stack overflow when it's specified in a configuration file, at least during my evaluation of maddy. I looked into what server.go does to fix it.

This also replaces the conditional for loading a client keypair with a more straightforward one. I suspect it may have been intentional, but as it's not documented I'm leaning towards it being a mistake.

I've verified that `tls_client` still works inside a `target.remote` block, and presents the configured certificate when requested.