### PR TITLE
Fix a typo in maddy-smtp man doc

### DIFF
--- a/docs/man/maddy-smtp.5.scd
+++ b/docs/man/maddy-smtp.5.scd
@@ -581,7 +581,7 @@ table.sql_table remote_addrs {
 }
 
 whatever {
-	destination_to &remote_addrs {
+	destination_in &remote_addrs {
 		deliver_to whatever
 	}
 }


### PR DESCRIPTION
I assume it was a leftover from copy-pasting stuff because I couldn't find a directive named `destination_to` anywhere.