### PR TITLE
Limit allowed header size

### DIFF
--- a/docs/man/maddy-smtp.5.scd
+++ b/docs/man/maddy-smtp.5.scd
@@ -18,6 +18,7 @@ smtp tcp://0.0.0.0:25 {
     read_timeout 10m
     write_timeout 1m
     max_message_size 32M
+    max_header_size 1M
     auth pam
     defer_sender_reject yes
     dmarc yes
@@ -89,6 +90,11 @@ I/O write timeout.
 *Default*: 32M
 
 Limit the size of incoming messages to 'size'.
+
+*Syntax*: max_header_size _size_ ++
+*Default*: 1M
+
+Limit the size of incoming message headers to 'size'.
 
 *Syntax*: auth _module_reference_ ++
 *Default*: not specified

--- a/internal/endpoint/smtp/smtp.go
+++ b/internal/endpoint/smtp/smtp.go
@@ -67,6 +67,7 @@ type Endpoint struct {
 	deferServerReject   bool
 	maxLoggedRcptErrors int
 	maxReceived         int
+	maxHeaderBytes      int
 
 	listenersWg sync.WaitGroup
 
@@ -245,6 +246,7 @@ func (endp *Endpoint) setConfig(cfg *config.Map) error {
 	cfg.Duration("write_timeout", false, false, 1*time.Minute, &endp.serv.WriteTimeout)
 	cfg.Duration("read_timeout", false, false, 10*time.Minute, &endp.serv.ReadTimeout)
 	cfg.DataSize("max_message_size", false, false, 32*1024*1024, &endp.serv.MaxMessageBytes)
+	cfg.DataSize("max_header_size", false, false, 1*1024*1024, &endp.maxHeaderBytes)
 	cfg.Int("max_recipients", false, false, 20000, &endp.serv.MaxRecipients)
 	cfg.Int("max_received", false, false, 50, &endp.maxReceived)
 	cfg.Custom("buffer", false, false, func() (interface{}, error) {

--- a/tests/smtp_test.go
+++ b/tests/smtp_test.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/foxcpp/go-mockdns"
@@ -452,6 +453,44 @@ func TestCheckCommand(tt *testing.T) {
 			t.Log([]byte(expectedMsg))
 		}
 	})
+
+	conn.Writeln("QUIT")
+	conn.ExpectPattern("221 *")
+}
+
+func TestHeaderSizeConstraint(tt *testing.T) {
+	tt.Parallel()
+	t := tests.NewT(tt)
+	t.DNS(nil)
+	t.Port("smtp")
+	t.Config(`
+		smtp tcp://127.0.0.1:{env:TEST_PORT_smtp} {
+			hostname mx.maddy.test
+			tls off
+			deliver_to dummy
+			max_header_size 1K
+		}
+	`)
+	t.Run(1)
+	defer t.Close()
+
+	conn := t.Conn("smtp")
+	defer conn.Close()
+	conn.SMTPNegotation("localhost", nil, nil)
+	conn.Writeln("MAIL FROM:<testsender@maddy.test>")
+	conn.ExpectPattern("250 *")
+	conn.Writeln("RCPT TO:<testing@maddy.test>")
+	conn.ExpectPattern("250 *")
+	conn.Writeln("DATA")
+	conn.ExpectPattern("354 *")
+	conn.Writeln("From: <testing@sender.test>")
+	conn.Writeln("To: <testing@maddy.test>")
+	conn.Writeln("Subject: " + strings.Repeat("A", 2*1024))
+	conn.Writeln("")
+	conn.Writeln("Hi")
+	conn.Writeln(".")
+
+	conn.ExpectPattern("552 5.3.4 Message header size exceeds limit *")
 
 	conn.Writeln("QUIT")
 	conn.ExpectPattern("221 *")


### PR DESCRIPTION
Implements header file check mentioned here https://github.com/foxcpp/maddy/issues/324

I've also added a test for max_message_size as subtest in the new test commited here. It fails with an internal server error tough. I'll check what's happening there and add the test in a separate pull request.