### PR TITLE
Add missing mailto: to DMARC ruf parameter in tutorial

### DIFF
--- a/docs/tutorials/setting-up.md
+++ b/docs/tutorials/setting-up.md
@@ -170,7 +170,7 @@ example.org.   TXT   "v=spf1 mx -all"
 
 ; Opt-in into DMARC with permissive policy and request reports about broken
 ; messages.
-_dmarc.example.org.   TXT    "v=DMARC1; p=none; ruf=postmaster@example.org"
+_dmarc.example.org.   TXT    "v=DMARC1; p=none; ruf=mailto:postmaster@example.org"
 ```
 
 And the last one, DKIM key, is a bit tricky. maddy generated a key for you on


### PR DESCRIPTION
Looks like it must include `mailto:` scheme to be valid. The rfc7489 does not mention it explicitly, though, I find no examples in the web for using it without scheme. Especially examples on dmarc.org itself.