### PR TITLE
refactor: remove/`_`-ify unused params

### DIFF
--- a/config.go
+++ b/config.go
@@ -40,7 +40,7 @@ type logOut struct {
 	log.Output
 }
 
-func logOutput(m *config.Map, node config.Node) (interface{}, error) {
+func logOutput(_ *config.Map, node config.Node) (interface{}, error) {
 	if len(node.Args) == 0 {
 		return nil, config.NodeErr(node, "expected at least 1 argument")
 	}

--- a/framework/config/map.go
+++ b/framework/config/map.go
@@ -83,7 +83,7 @@ func (m *Map) AllowUnknown() {
 func (m *Map) EnumList(name string, inheritGlobal, required bool, allowed []string, defaultVal []string, store *[]string) {
 	m.Custom(name, inheritGlobal, required, func() (interface{}, error) {
 		return defaultVal, nil
-	}, func(m *Map, node Node) (interface{}, error) {
+	}, func(_ *Map, node Node) (interface{}, error) {
 		if len(node.Children) != 0 {
 			return nil, NodeErr(node, "can't declare a block here")
 		}
@@ -116,7 +116,7 @@ func (m *Map) EnumList(name string, inheritGlobal, required bool, allowed []stri
 func (m *Map) Enum(name string, inheritGlobal, required bool, allowed []string, defaultVal string, store *string) {
 	m.Custom(name, inheritGlobal, required, func() (interface{}, error) {
 		return defaultVal, nil
-	}, func(m *Map, node Node) (interface{}, error) {
+	}, func(_ *Map, node Node) (interface{}, error) {
 		if len(node.Children) != 0 {
 			return nil, NodeErr(node, "can't declare a block here")
 		}
@@ -148,7 +148,7 @@ func (m *Map) Enum(name string, inheritGlobal, required bool, allowed []string, 
 func (m *Map) Duration(name string, inheritGlobal, required bool, defaultVal time.Duration, store *time.Duration) {
 	m.Custom(name, inheritGlobal, required, func() (interface{}, error) {
 		return defaultVal, nil
-	}, func(m *Map, node Node) (interface{}, error) {
+	}, func(_ *Map, node Node) (interface{}, error) {
 		if len(node.Children) != 0 {
 			return nil, NodeErr(node, "can't declare block here")
 		}
@@ -234,7 +234,7 @@ func ParseDataSize(s string) (int, error) {
 func (m *Map) DataSize(name string, inheritGlobal, required bool, defaultVal int, store *int) {
 	m.Custom(name, inheritGlobal, required, func() (interface{}, error) {
 		return defaultVal, nil
-	}, func(m *Map, node Node) (interface{}, error) {
+	}, func(_ *Map, node Node) (interface{}, error) {
 		if len(node.Children) != 0 {
 			return nil, NodeErr(node, "can't declare block here")
 		}
@@ -262,7 +262,7 @@ func (m *Map) DataSize(name string, inheritGlobal, required bool, defaultVal int
 func (m *Map) Bool(name string, inheritGlobal, defaultVal bool, store *bool) {
 	m.Custom(name, inheritGlobal, false, func() (interface{}, error) {
 		return defaultVal, nil
-	}, func(m *Map, node Node) (interface{}, error) {
+	}, func(_ *Map, node Node) (interface{}, error) {
 		if len(node.Children) != 0 {
 			return nil, NodeErr(node, "can't declare block here")
 		}
@@ -295,7 +295,7 @@ func (m *Map) Bool(name string, inheritGlobal, defaultVal bool, store *bool) {
 func (m *Map) StringList(name string, inheritGlobal, required bool, defaultVal []string, store *[]string) {
 	m.Custom(name, inheritGlobal, required, func() (interface{}, error) {
 		return defaultVal, nil
-	}, func(m *Map, node Node) (interface{}, error) {
+	}, func(_ *Map, node Node) (interface{}, error) {
 		if len(node.Args) == 0 {
 			return nil, NodeErr(node, "expected at least one argument")
 		}
@@ -317,7 +317,7 @@ func (m *Map) StringList(name string, inheritGlobal, required bool, defaultVal [
 func (m *Map) String(name string, inheritGlobal, required bool, defaultVal string, store *string) {
 	m.Custom(name, inheritGlobal, required, func() (interface{}, error) {
 		return defaultVal, nil
-	}, func(m *Map, node Node) (interface{}, error) {
+	}, func(_ *Map, node Node) (interface{}, error) {
 		if len(node.Args) != 1 {
 			return nil, NodeErr(node, "expected 1 argument")
 		}
@@ -339,7 +339,7 @@ func (m *Map) String(name string, inheritGlobal, required bool, defaultVal strin
 func (m *Map) Int(name string, inheritGlobal, required bool, defaultVal int, store *int) {
 	m.Custom(name, inheritGlobal, required, func() (interface{}, error) {
 		return defaultVal, nil
-	}, func(m *Map, node Node) (interface{}, error) {
+	}, func(_ *Map, node Node) (interface{}, error) {
 		if len(node.Args) != 1 {
 			return nil, NodeErr(node, "expected 1 argument")
 		}
@@ -365,7 +365,7 @@ func (m *Map) Int(name string, inheritGlobal, required bool, defaultVal int, sto
 func (m *Map) UInt(name string, inheritGlobal, required bool, defaultVal uint, store *uint) {
 	m.Custom(name, inheritGlobal, required, func() (interface{}, error) {
 		return defaultVal, nil
-	}, func(m *Map, node Node) (interface{}, error) {
+	}, func(_ *Map, node Node) (interface{}, error) {
 		if len(node.Args) != 1 {
 			return nil, NodeErr(node, "expected 1 argument")
 		}
@@ -391,7 +391,7 @@ func (m *Map) UInt(name string, inheritGlobal, required bool, defaultVal uint, s
 func (m *Map) Int32(name string, inheritGlobal, required bool, defaultVal int32, store *int32) {
 	m.Custom(name, inheritGlobal, required, func() (interface{}, error) {
 		return defaultVal, nil
-	}, func(m *Map, node Node) (interface{}, error) {
+	}, func(_ *Map, node Node) (interface{}, error) {
 		if len(node.Args) != 1 {
 			return nil, NodeErr(node, "expected 1 argument")
 		}
@@ -417,7 +417,7 @@ func (m *Map) Int32(name string, inheritGlobal, required bool, defaultVal int32,
 func (m *Map) UInt32(name string, inheritGlobal, required bool, defaultVal uint32, store *uint32) {
 	m.Custom(name, inheritGlobal, required, func() (interface{}, error) {
 		return defaultVal, nil
-	}, func(m *Map, node Node) (interface{}, error) {
+	}, func(_ *Map, node Node) (interface{}, error) {
 		if len(node.Args) != 1 {
 			return nil, NodeErr(node, "expected 1 argument")
 		}
@@ -443,7 +443,7 @@ func (m *Map) UInt32(name string, inheritGlobal, required bool, defaultVal uint3
 func (m *Map) Int64(name string, inheritGlobal, required bool, defaultVal int64, store *int64) {
 	m.Custom(name, inheritGlobal, required, func() (interface{}, error) {
 		return defaultVal, nil
-	}, func(m *Map, node Node) (interface{}, error) {
+	}, func(_ *Map, node Node) (interface{}, error) {
 		if len(node.Args) != 1 {
 			return nil, NodeErr(node, "expected 1 argument")
 		}
@@ -469,7 +469,7 @@ func (m *Map) Int64(name string, inheritGlobal, required bool, defaultVal int64,
 func (m *Map) UInt64(name string, inheritGlobal, required bool, defaultVal uint64, store *uint64) {
 	m.Custom(name, inheritGlobal, required, func() (interface{}, error) {
 		return defaultVal, nil
-	}, func(m *Map, node Node) (interface{}, error) {
+	}, func(_ *Map, node Node) (interface{}, error) {
 		if len(node.Args) != 1 {
 			return nil, NodeErr(node, "expected 1 argument")
 		}
@@ -495,7 +495,7 @@ func (m *Map) UInt64(name string, inheritGlobal, required bool, defaultVal uint6
 func (m *Map) Float(name string, inheritGlobal, required bool, defaultVal float64, store *float64) {
 	m.Custom(name, inheritGlobal, required, func() (interface{}, error) {
 		return defaultVal, nil
-	}, func(m *Map, node Node) (interface{}, error) {
+	}, func(_ *Map, node Node) (interface{}, error) {
 		if len(node.Args) != 1 {
 			return nil, NodeErr(node, "expected 1 argument")
 		}

--- a/internal/dsn/dsn.go
+++ b/internal/dsn/dsn.go
@@ -204,7 +204,7 @@ func GenerateDSN(utf8 bool, envelope Envelope, mtaInfo ReportingMTAInfo, rcptsIn
 
 	defer partWriter.Close()
 
-	if err := writeHumanReadablePart(partWriter, envelope, mtaInfo, rcptsInfo); err != nil {
+	if err := writeHumanReadablePart(partWriter, mtaInfo, rcptsInfo); err != nil {
 		return textproto.Header{}, err
 	}
 	if err := writeMachineReadablePart(utf8, partWriter, mtaInfo, rcptsInfo); err != nil {
@@ -271,7 +271,7 @@ Last delivery attempt: {{.LastAttemptDate}}
 
 `))
 
-func writeHumanReadablePart(w *textproto.MultipartWriter, envelope Envelope, mtaInfo ReportingMTAInfo, rcptsInfo []RecipientInfo) error {
+func writeHumanReadablePart(w *textproto.MultipartWriter, mtaInfo ReportingMTAInfo, rcptsInfo []RecipientInfo) error {
 	humanHeader := textproto.Header{}
 	humanHeader.Add("Content-Transfer-Encoding", "8bit")
 	humanHeader.Add("Content-Type", `text/plain; charset="utf-8"`)

--- a/internal/endpoint/smtp/session.go
+++ b/internal/endpoint/smtp/session.go
@@ -364,7 +364,7 @@ func (s *Session) Logout() error {
 	return nil
 }
 
-func (s *Session) prepareBody(ctx context.Context, r io.Reader) (textproto.Header, buffer.Buffer, error) {
+func (s *Session) prepareBody(r io.Reader) (textproto.Header, buffer.Buffer, error) {
 	limitr := limitReader(r, int64(s.endp.maxHeaderBytes), &exterrors.SMTPError{
 		Code:         552,
 		EnhancedCode: exterrors.EnhancedCode{5, 3, 4},
@@ -407,7 +407,7 @@ func (s *Session) Data(r io.Reader) error {
 		return s.endp.wrapErr(s.msgMeta.ID, !s.opts.UTF8, "DATA", err)
 	}
 
-	header, buf, err := s.prepareBody(bodyCtx, r)
+	header, buf, err := s.prepareBody(r)
 	if err != nil {
 		return wrapErr(err)
 	}
@@ -462,7 +462,7 @@ func (s *Session) LMTPData(r io.Reader, sc smtp.StatusCollector) error {
 		return s.endp.wrapErr(s.msgMeta.ID, !s.opts.UTF8, "DATA", err)
 	}
 
-	header, buf, err := s.prepareBody(bodyCtx, r)
+	header, buf, err := s.prepareBody(r)
 	if err != nil {
 		return wrapErr(err)
 	}

--- a/internal/endpoint/smtp/smtp.go
+++ b/internal/endpoint/smtp/smtp.go
@@ -178,7 +178,7 @@ func autoBufferMode(maxSize int, dir string) func(io.Reader) (buffer.Buffer, err
 	}
 }
 
-func bufferModeDirective(m *config.Map, node config.Node) (interface{}, error) {
+func bufferModeDirective(_ *config.Map, node config.Node) (interface{}, error) {
 	if len(node.Args) < 1 {
 		return nil, config.NodeErr(node, "at least one argument required")
 	}
@@ -316,7 +316,7 @@ func (endp *Endpoint) setConfig(cfg *config.Map) error {
 			}
 
 			return endp.saslAuth.CreateSASL(mech, state.RemoteAddr, func(id string) error {
-				c.SetSession(endp.newSession(false, id, "", &state))
+				c.SetSession(endp.newSession(id, "", &state))
 				return nil
 			})
 		})
@@ -393,7 +393,7 @@ func (endp *Endpoint) Login(state *smtp.ConnectionState, username, password stri
 		}
 	}
 
-	return endp.newSession(false, username, password, state), nil
+	return endp.newSession(username, password, state), nil
 }
 
 func (endp *Endpoint) AnonymousLogin(state *smtp.ConnectionState) (smtp.Session, error) {
@@ -406,10 +406,10 @@ func (endp *Endpoint) AnonymousLogin(state *smtp.ConnectionState) (smtp.Session,
 		return nil, endp.wrapErr("", true, "MAIL", err)
 	}
 
-	return endp.newSession(true, "", "", state), nil
+	return endp.newSession("", "", state), nil
 }
 
-func (endp *Endpoint) newSession(anonymous bool, username, password string, state *smtp.ConnectionState) smtp.Session {
+func (endp *Endpoint) newSession(username, password string, state *smtp.ConnectionState) smtp.Session {
 	s := &Session{
 		endp: endp,
 		log:  endp.Log,

--- a/internal/endpoint/smtp/submission_test.go
+++ b/internal/endpoint/smtp/submission_test.go
@@ -92,74 +92,74 @@ func TestSubmissionPrepare(t *testing.T) {
 
 	// Malformed From field.
 	test(map[string][]string{
-		"From": []string{"<hello@example.org>, \"\""},
+		"From": {"<hello@example.org>, \"\""},
 	}, nil)
 	test(map[string][]string{
-		"From": []string{" adasda"},
+		"From": {" adasda"},
 	}, nil)
 
 	// Malformed Reply-To.
 	test(map[string][]string{
-		"From":     []string{"<hello@example.org>"},
-		"Reply-To": []string{"<hello@example.org>, \"\""},
+		"From":     {"<hello@example.org>"},
+		"Reply-To": {"<hello@example.org>, \"\""},
 	}, nil)
 
 	// Malformed CC.
 	test(map[string][]string{
-		"From":     []string{"<hello@example.org>"},
-		"Reply-To": []string{"<hello@example.org>"},
-		"Cc":       []string{"<hello@example.org>, \"\""},
+		"From":     {"<hello@example.org>"},
+		"Reply-To": {"<hello@example.org>"},
+		"Cc":       {"<hello@example.org>, \"\""},
 	}, nil)
 
 	// Malformed Sender.
 	test(map[string][]string{
-		"From":     []string{"<hello@example.org>"},
-		"Reply-To": []string{"<hello@example.org>"},
-		"Cc":       []string{"<hello@example.org>"},
-		"Sender":   []string{"<hello@example.org> asd"},
+		"From":     {"<hello@example.org>"},
+		"Reply-To": {"<hello@example.org>"},
+		"Cc":       {"<hello@example.org>"},
+		"Sender":   {"<hello@example.org> asd"},
 	}, nil)
 
 	// Multiple From + no Sender.
 	test(map[string][]string{
-		"From": []string{"<hello@example.org>, <hello2@example.org>"},
+		"From": {"<hello@example.org>, <hello2@example.org>"},
 	}, nil)
 
 	// Multiple From + valid Sender.
 	test(map[string][]string{
-		"From":       []string{"<hello@example.org>, <hello2@example.org>"},
-		"Sender":     []string{"<hello@example.org>"},
-		"Date":       []string{"Fri, 22 Nov 2019 20:51:31 +0800"},
-		"Message-Id": []string{"<foobar@example.org>"},
+		"From":       {"<hello@example.org>, <hello2@example.org>"},
+		"Sender":     {"<hello@example.org>"},
+		"Date":       {"Fri, 22 Nov 2019 20:51:31 +0800"},
+		"Message-Id": {"<foobar@example.org>"},
 	}, map[string][]string{
-		"From":       []string{"<hello@example.org>, <hello2@example.org>"},
-		"Sender":     []string{"<hello@example.org>"},
-		"Date":       []string{"Fri, 22 Nov 2019 20:51:31 +0800"},
-		"Message-Id": []string{"<foobar@example.org>"},
+		"From":       {"<hello@example.org>, <hello2@example.org>"},
+		"Sender":     {"<hello@example.org>"},
+		"Date":       {"Fri, 22 Nov 2019 20:51:31 +0800"},
+		"Message-Id": {"<foobar@example.org>"},
 	})
 
 	// Add missing Message-Id.
 	test(map[string][]string{
-		"From": []string{"<hello@example.org>"},
-		"Date": []string{"Fri, 22 Nov 2019 20:51:31 +0800"},
+		"From": {"<hello@example.org>"},
+		"Date": {"Fri, 22 Nov 2019 20:51:31 +0800"},
 	}, map[string][]string{
-		"From":       []string{"<hello@example.org>"},
-		"Date":       []string{"Fri, 22 Nov 2019 20:51:31 +0800"},
-		"Message-Id": []string{"<A@mx.example.com>"},
+		"From":       {"<hello@example.org>"},
+		"Date":       {"Fri, 22 Nov 2019 20:51:31 +0800"},
+		"Message-Id": {"<A@mx.example.com>"},
 	})
 
 	// Malformed Date.
 	test(map[string][]string{
-		"From": []string{"<hello@example.org>"},
-		"Date": []string{"not a date"},
+		"From": {"<hello@example.org>"},
+		"Date": {"not a date"},
 	}, nil)
 
 	// Add missing Date.
 	test(map[string][]string{
-		"From":       []string{"<hello@example.org>"},
-		"Message-Id": []string{"<A@mx.example.org>"},
+		"From":       {"<hello@example.org>"},
+		"Message-Id": {"<A@mx.example.org>"},
 	}, map[string][]string{
-		"From":       []string{"<hello@example.org>"},
-		"Message-Id": []string{"<A@mx.example.org>"},
-		"Date":       []string{"Thu, 1 Jan 1970 00:00:00 +0000"},
+		"From":       {"<hello@example.org>"},
+		"Message-Id": {"<A@mx.example.org>"},
+		"Date":       {"Thu, 1 Jan 1970 00:00:00 +0000"},
 	})
 }

--- a/internal/modify/dkim/dkim_test.go
+++ b/internal/modify/dkim/dkim_test.go
@@ -174,6 +174,8 @@ func TestGenerateSignVerify(t *testing.T) {
 		defer os.RemoveAll(dir)
 
 		m := newTestModifier(t, dir, keyAlgo, domains)
+		m.bodyCanon = bodyCanon
+		m.headerCanon = headerCanon
 		if reload {
 			m = newTestModifier(t, dir, keyAlgo, domains)
 		}

--- a/internal/modify/replace_addr_test.go
+++ b/internal/modify/replace_addr_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/foxcpp/maddy/internal/testutils"
 )
 
-func testReplaceAddr(t *testing.T, modName string, rewriter func(*replaceAddr, context.Context, string) (string, error)) {
+func testReplaceAddr(t *testing.T, modName string) {
 	test := func(addr, expected string, aliases map[string]string) {
 		t.Helper()
 
@@ -95,9 +95,9 @@ func testReplaceAddr(t *testing.T, modName string, rewriter func(*replaceAddr, c
 }
 
 func TestReplaceAddr_RewriteSender(t *testing.T) {
-	testReplaceAddr(t, "modify.replace_sender", (*replaceAddr).RewriteSender)
+	testReplaceAddr(t, "modify.replace_sender")
 }
 
 func TestReplaceAddr_RewriteRcpt(t *testing.T) {
-	testReplaceAddr(t, "modify.replace_rcpt", (*replaceAddr).RewriteRcpt)
+	testReplaceAddr(t, "modify.replace_rcpt")
 }

--- a/internal/target/remote/mxauth_test.go
+++ b/internal/target/remote/mxauth_test.go
@@ -47,7 +47,7 @@ func TestRemoteDelivery_AuthMX_MTASTS(t *testing.T) {
 		},
 	}
 
-	mtastsGet := func(ctx context.Context, domain string) (*mtasts.Policy, error) {
+	mtastsGet := func(_ context.Context, domain string) (*mtasts.Policy, error) {
 		if domain != "example.invalid" {
 			return nil, errors.New("Wrong domain in lookup")
 		}
@@ -92,7 +92,7 @@ func TestRemoteDelivery_MTASTS_SkipNonMatching(t *testing.T) {
 		},
 	}
 
-	mtastsGet := func(ctx context.Context, domain string) (*mtasts.Policy, error) {
+	mtastsGet := func(_ context.Context, domain string) (*mtasts.Policy, error) {
 		if domain != "example.invalid" {
 			return nil, errors.New("Wrong domain in lookup")
 		}
@@ -132,7 +132,7 @@ func TestRemoteDelivery_AuthMX_MTASTS_Fail(t *testing.T) {
 		},
 	}
 
-	mtastsGet := func(ctx context.Context, domain string) (*mtasts.Policy, error) {
+	mtastsGet := func(_ context.Context, domain string) (*mtasts.Policy, error) {
 		if domain != "example.invalid" {
 			return nil, errors.New("Wrong domain in lookup")
 		}
@@ -174,7 +174,7 @@ func TestRemoteDelivery_AuthMX_MTASTS_NoTLS(t *testing.T) {
 		},
 	}
 
-	mtastsGet := func(ctx context.Context, domain string) (*mtasts.Policy, error) {
+	mtastsGet := func(_ context.Context, domain string) (*mtasts.Policy, error) {
 		if domain != "example.invalid" {
 			return nil, errors.New("Wrong domain in lookup")
 		}
@@ -215,7 +215,7 @@ func TestRemoteDelivery_AuthMX_MTASTS_RequirePKIX(t *testing.T) {
 		},
 	}
 
-	mtastsGet := func(ctx context.Context, domain string) (*mtasts.Policy, error) {
+	mtastsGet := func(_ context.Context, domain string) (*mtasts.Policy, error) {
 		if domain != "example.invalid" {
 			return nil, errors.New("Wrong domain in lookup")
 		}
@@ -268,7 +268,7 @@ func TestRemoteDelivery_AuthMX_MTASTS_NoPolicy(t *testing.T) {
 		},
 	}
 
-	mtastsGet := func(ctx context.Context, domain string) (*mtasts.Policy, error) {
+	mtastsGet := func(_ context.Context, domain string) (*mtasts.Policy, error) {
 		if domain != "example.invalid" {
 			return nil, errors.New("Wrong domain in lookup")
 		}
@@ -389,7 +389,7 @@ func TestRemoteDelivery_REQUIRETLS(t *testing.T) {
 		},
 	}
 
-	mtastsGet := func(ctx context.Context, domain string) (*mtasts.Policy, error) {
+	mtastsGet := func(_ context.Context, domain string) (*mtasts.Policy, error) {
 		if domain != "example.invalid" {
 			return nil, errors.New("Wrong domain in lookup")
 		}
@@ -430,7 +430,7 @@ func TestRemoteDelivery_REQUIRETLS_Fail(t *testing.T) {
 		},
 	}
 
-	mtastsGet := func(ctx context.Context, domain string) (*mtasts.Policy, error) {
+	mtastsGet := func(_ context.Context, domain string) (*mtasts.Policy, error) {
 		if domain != "example.invalid" {
 			return nil, errors.New("Wrong domain in lookup")
 		}
@@ -475,7 +475,7 @@ func TestRemoteDelivery_REQUIRETLS_Relaxed(t *testing.T) {
 		},
 	}
 
-	mtastsGet := func(ctx context.Context, domain string) (*mtasts.Policy, error) {
+	mtastsGet := func(_ context.Context, domain string) (*mtasts.Policy, error) {
 		if domain != "example.invalid" {
 			return nil, errors.New("Wrong domain in lookup")
 		}
@@ -517,7 +517,7 @@ func TestRemoteDelivery_REQUIRETLS_Relaxed_NoMXAuth(t *testing.T) {
 		},
 	}
 
-	mtastsGet := func(ctx context.Context, domain string) (*mtasts.Policy, error) {
+	mtastsGet := func(_ context.Context, domain string) (*mtasts.Policy, error) {
 		if domain != "example.invalid" {
 			return nil, errors.New("Wrong domain in lookup")
 		}
@@ -558,7 +558,7 @@ func TestRemoteDelivery_REQUIRETLS_Relaxed_NoTLS(t *testing.T) {
 		},
 	}
 
-	mtastsGet := func(ctx context.Context, domain string) (*mtasts.Policy, error) {
+	mtastsGet := func(_ context.Context, domain string) (*mtasts.Policy, error) {
 		if domain != "example.invalid" {
 			return nil, errors.New("Wrong domain in lookup")
 		}
@@ -604,7 +604,7 @@ func TestRemoteDelivery_REQUIRETLS_Relaxed_TLSFail(t *testing.T) {
 		},
 	}
 
-	mtastsGet := func(ctx context.Context, domain string) (*mtasts.Policy, error) {
+	mtastsGet := func(_ context.Context, domain string) (*mtasts.Policy, error) {
 		if domain != "example.invalid" {
 			return nil, errors.New("Wrong domain in lookup")
 		}

--- a/internal/target/remote/remote_test.go
+++ b/internal/target/remote/remote_test.go
@@ -92,6 +92,7 @@ func testSTSPolicy(t *testing.T, zones map[string]mockdns.Zone, mtastsGet func(c
 
 	p.mtastsGet = mtastsGet
 	p.log = testutils.Logger(t, "remote/mtasts")
+	p.cache.Resolver = &mockdns.Resolver{Zones: zones}
 	p.StartUpdater()
 
 	return p


### PR DESCRIPTION
Hi!

I've removed some unused params. But if they where needed for e.g. interface type I've simply `_` them. Also I have 2 instances to fix tests params, whereby they were passed but not initialized at all, they are in`internal/target/remote/remote_test.go` and `internal/modify/dkim/dkim_test.go`. All test are still passing so it seems like I didn't break anything.

I might've refactored some code away that actually is used but wasn't implemented correctly, but as far as I see their is nothing wrong or erroring going on.