### PR TITLE
Set ExecStart path to the same as the default in build.sh

### DIFF
--- a/dist/systemd/maddy.service
+++ b/dist/systemd/maddy.service
@@ -69,7 +69,7 @@ Restart=on-failure
 # ... Unless it is a configuration problem.
 RestartPreventExitStatus=2
 
-ExecStart=/usr/bin/maddy
+ExecStart=/usr/local/bin/maddy
 
 ExecReload=/bin/kill -USR1 $MAINPID
 ExecReload=/bin/kill -USR2 $MAINPID

--- a/dist/systemd/maddy@.service
+++ b/dist/systemd/maddy@.service
@@ -65,7 +65,7 @@ Restart=on-failure
 # ... Unless it is a configuration problem.
 RestartPreventExitStatus=2
 
-ExecStart=/usr/bin/maddy -config /etc/maddy/%i.conf
+ExecStart=/usr/local/bin/maddy -config /etc/maddy/%i.conf
 
 ExecReload=/bin/kill -USR1 $MAINPID
 ExecReload=/bin/kill -USR2 $MAINPID


### PR DESCRIPTION
This is really only a half fix as I see that you can pass a prefix to the build script. 
Closes #390 