### PR TITLE
dist: Set ProtectClock, RestrictAddressFamilies and CapabilityBoundingSet

### DIFF
--- a/dist/systemd/maddy.service
+++ b/dist/systemd/maddy.service
@@ -29,7 +29,9 @@ ProtectHome=true
 ProtectSystem=strict
 ProtectKernelTunables=true
 ProtectHostname=true
+ProtectClock=true
 ProtectControlGroups=true
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
 
 # Additional sandboxing. You need to disable all of these options
 # for privileged helper binaries (for system auth) to work correctly.
@@ -50,6 +52,7 @@ KillSignal=SIGTERM
 
 # Required to bind on ports lower than 1024.
 AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 
 # Force all files created by maddy to be only readable by it.
 UMask=0027

--- a/dist/systemd/maddy@.service
+++ b/dist/systemd/maddy@.service
@@ -25,7 +25,9 @@ PrivateHome=true
 ProtectSystem=strict
 ProtectKernelTunables=true
 ProtectHostname=true
+ProtectClock=true
 ProtectControlGroups=true
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
 DeviceAllow=/dev/syslog
 
 # Additional sandboxing. You need to disable all of these options
@@ -46,6 +48,7 @@ KillSignal=SIGTERM
 
 # Required to bind on ports lower than 1024.
 AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 
 # Force all files created by maddy to be only readable by it.
 UMask=0027


### PR DESCRIPTION
This increases the isolation of Maddy service.
Maddy capabilities can be bound to only `CAP_NET_BIND_SERVICE` with `CapabilityBoundingSet`.
`RestrictAddressFamilies` restricts the service to only use Unix sockets, IPv4 and IPv6.

-- 
Alexandre
Thank you for developing this awesome mail server.