### PR TITLE
smtp/session: move conditional to outer loop

### DIFF
--- a/internal/endpoint/smtp/session.go
+++ b/internal/endpoint/smtp/session.go
@@ -202,12 +202,14 @@ func (s *Session) startDelivery(ctx context.Context, from string, opts smtp.Mail
 
 	// INTERNATIONALIZATION: Do not permit non-ASCII addresses unless SMTPUTF8 is
 	// used.
-	for _, ch := range from {
-		if ch > 128 && !opts.UTF8 {
-			return "", &exterrors.SMTPError{
-				Code:         550,
-				EnhancedCode: exterrors.EnhancedCode{5, 6, 7},
-				Message:      "SMTPUTF8 is required for non-ASCII senders",
+	if !opts.UTF8 {
+		for _, ch := range from {
+			if ch > 128 {
+				return "", &exterrors.SMTPError{
+					Code:         550,
+					EnhancedCode: exterrors.EnhancedCode{5, 6, 7},
+					Message:      "SMTPUTF8 is required for non-ASCII senders",
+				}
 			}
 		}
 	}


### PR DESCRIPTION
- Only loop trough the `from` email address if UTF8 option is not enabled. This should avoid unnecessary loops for servers which has the UTF8 option enabled.