### PR TITLE
dmarc: only ResultPass if both DKIM and SPF are Aligned

### DIFF
--- a/internal/dmarc/evaluate.go
+++ b/internal/dmarc/evaluate.go
@@ -193,7 +193,7 @@ func EvaluateAlignment(fromDomain string, record *Record, results []authres.Resu
 	}
 
 	res.Authres.From = fromDomain
-	if dkimAligned || spfAligned {
+	if dkimAligned && spfAligned {
 		res.Authres.Value = authres.ResultPass
 	} else {
 		res.Authres.Value = authres.ResultFail


### PR DESCRIPTION
In my case the DKIM Result was fine, but SPF fails, In that case i expect an DMARC failure. But the Dmarc was ResultNone

Please correct me if i am wrong.