### PR TITLE
Fix unintentional git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,6 @@ _testmain.go
 cmd/maddy/maddy
 cmd/maddyctl/maddyctl
 cmd/maddy-*-helper/maddy-*-helper
-maddy
-maddyctl
 
 # Man pages
 docs/man/*.1


### PR DESCRIPTION
cmd/maddy folder should not be ignored

```
~/go/src/github.com/foxcpp/maddy master
❯ git status
On branch master
Your branch is up to date with 'origin/master'.

nothing to commit, working tree clean

~/go/src/github.com/foxcpp/maddy master
❯ touch  cmd/maddy/dummy

~/go/src/github.com/foxcpp/maddy master
❯ git status 
On branch master
Your branch is up to date with 'origin/master'.

nothing to commit, working tree clean

~/go/src/github.com/foxcpp/maddy master
❯ 
```

Spent few minutes trying to find out the entry point as ripgrep failed to search this dir because of this bug.
```
❯ rg 'func main()'
tests/gocovcat.go
42:func main() {

cmd/maddy-shadow-helper/main.go
30:func main() {

cmd/maddy-pam-helper/main.go
35:func main() {

```