### PR TITLE
Add more fields to imap_filter

### DIFF
--- a/docs/man/maddy-imap.5.scd
+++ b/docs/man/maddy-imap.5.scd
@@ -96,8 +96,8 @@ command executable_name args... { }
 
 Same as check.command, following placeholders are supported for command
 arguments: {source_ip}, {source_host}, {source_rdns}, {msg_id}, {auth_user},
-{sender}. Note: placeholders in command name are not processed to avoid 
-possible command injection attacks.
+{sender}, {rcpts}, {address}. Note: placeholders in command name are not
+processed to avoid possible command injection attacks.
 
 Additionally, for imap.filter.command, {account_name} placeholder is replaced
 with effective IMAP account name.

--- a/docs/man/maddy-imap.5.scd
+++ b/docs/man/maddy-imap.5.scd
@@ -96,8 +96,8 @@ command executable_name args... { }
 
 Same as check.command, following placeholders are supported for command
 arguments: {source_ip}, {source_host}, {source_rdns}, {msg_id}, {auth_user},
-{sender}, {rcpt_to}, {original_rcpt_to}, {address}. Note: placeholders in command
-name are not processed to avoid possible command injection attacks.
+{sender}, {rcpt_to}, {original_rcpt_to}, {address}, {subject}. Note: placeholders
+in command name are not processed to avoid possible command injection attacks.
 
 Additionally, for imap.filter.command, {account_name} placeholder is replaced
 with effective IMAP account name.

--- a/docs/man/maddy-imap.5.scd
+++ b/docs/man/maddy-imap.5.scd
@@ -96,8 +96,9 @@ command executable_name args... { }
 
 Same as check.command, following placeholders are supported for command
 arguments: {source_ip}, {source_host}, {source_rdns}, {msg_id}, {auth_user},
-{sender}, {rcpts}, {address}. Note: placeholders in command name are not
-processed to avoid possible command injection attacks.
+{sender}, {rcpt_to}, {original_rcpts}, {original_rcpt_to}, {address}. Note:
+placeholders in command name are not processed to avoid possible command
+injection attacks.
 
 Additionally, for imap.filter.command, {account_name} placeholder is replaced
 with effective IMAP account name.

--- a/docs/man/maddy-imap.5.scd
+++ b/docs/man/maddy-imap.5.scd
@@ -96,9 +96,8 @@ command executable_name args... { }
 
 Same as check.command, following placeholders are supported for command
 arguments: {source_ip}, {source_host}, {source_rdns}, {msg_id}, {auth_user},
-{sender}, {rcpt_to}, {original_rcpts}, {original_rcpt_to}, {address}. Note:
-placeholders in command name are not processed to avoid possible command
-injection attacks.
+{sender}, {rcpt_to}, {original_rcpt_to}, {address}. Note: placeholders in command
+name are not processed to avoid possible command injection attacks.
 
 Additionally, for imap.filter.command, {account_name} placeholder is replaced
 with effective IMAP account name.

--- a/framework/module/imap_filter.go
+++ b/framework/module/imap_filter.go
@@ -39,5 +39,5 @@ type IMAPFilter interface {
 	//
 	// Errors returned by IMAPFilter will be just logged and will not cause delivery
 	// to fail.
-	IMAPFilter(accountName string, meta *MsgMetadata, hdr textproto.Header, body buffer.Buffer) (folder string, flags []string, err error)
+	IMAPFilter(accountName string, rcptTo string, meta *MsgMetadata, hdr textproto.Header, body buffer.Buffer) (folder string, flags []string, err error)
 }

--- a/internal/imap_filter/command/command.go
+++ b/internal/imap_filter/command/command.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"strings"
 
 	"github.com/emersion/go-message/textproto"
 	"github.com/foxcpp/maddy/framework/buffer"
@@ -127,15 +128,23 @@ func (c *Check) expandCommand(msgMeta *module.MsgMetadata, accountName string) (
 				valI, err := msgMeta.Conn.RDNSName.Get()
 				if err != nil {
 					return ""
-				}
+				}x
 				if valI == nil {
-					return ""
+					return ""x
 				}
 				return valI.(string)
 			case "{msg_id}":
 				return msgMeta.ID
 			case "{sender}":
 				return msgMeta.OriginalFrom
+			case "{rcpts}":
+				rcpts := []string{}
+				for _, value := range msgMeta.OriginalRcpts {
+					rcpts = append(rcpts, value)
+				}
+				return strings.Join(rcpts, "\n")
+			case "{address}":
+				return msgMeta.OriginalRcpts[accountName]
 			case "{account_name}":
 				return accountName
 			}

--- a/internal/imap_filter/command/command.go
+++ b/internal/imap_filter/command/command.go
@@ -49,8 +49,8 @@ type Check struct {
 	cmdArgs []string
 }
 
-func (c *Check) IMAPFilter(accountName string, msgMeta *module.MsgMetadata, hdr textproto.Header, body buffer.Buffer) (folder string, flags []string, err error) {
-	cmd, args := c.expandCommand(msgMeta, accountName)
+func (c *Check) IMAPFilter(accountName string, rcptTo string, msgMeta *module.MsgMetadata, hdr textproto.Header, body buffer.Buffer) (folder string, flags []string, err error) {
+	cmd, args := c.expandCommand(msgMeta, accountName, rcptTo)
 
 	var buf bytes.Buffer
 	_ = textproto.WriteHeader(&buf, hdr)
@@ -96,7 +96,7 @@ func (c *Check) Init(cfg *config.Map) error {
 	return err
 }
 
-func (c *Check) expandCommand(msgMeta *module.MsgMetadata, accountName string) (string, []string) {
+func (c *Check) expandCommand(msgMeta *module.MsgMetadata, accountName string, rcptTo string) (string, []string) {
 	expArgs := make([]string, len(c.cmdArgs))
 
 	for i, arg := range c.cmdArgs {
@@ -137,14 +137,16 @@ func (c *Check) expandCommand(msgMeta *module.MsgMetadata, accountName string) (
 				return msgMeta.ID
 			case "{sender}":
 				return msgMeta.OriginalFrom
-			case "{rcpts}":
+			case "{rcpt_to}":
+				return rcptTo
+			case "{original_rcpts}":
 				rcpts := []string{}
 				for _, value := range msgMeta.OriginalRcpts {
 					rcpts = append(rcpts, value)
 				}
 				return strings.Join(rcpts, "\n")
-			case "{address}":
-				return msgMeta.OriginalRcpts[accountName]
+			case "{original_rcpt_to}":
+				return msgMeta.OriginalRcpts[rcptTo]
 			case "{account_name}":
 				return accountName
 			}

--- a/internal/imap_filter/command/command.go
+++ b/internal/imap_filter/command/command.go
@@ -28,7 +28,6 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
-	"strings"
 
 	"github.com/emersion/go-message/textproto"
 	"github.com/foxcpp/maddy/framework/buffer"
@@ -139,14 +138,12 @@ func (c *Check) expandCommand(msgMeta *module.MsgMetadata, accountName string, r
 				return msgMeta.OriginalFrom
 			case "{rcpt_to}":
 				return rcptTo
-			case "{original_rcpts}":
-				rcpts := []string{}
-				for _, value := range msgMeta.OriginalRcpts {
-					rcpts = append(rcpts, value)
-				}
-				return strings.Join(rcpts, "\n")
 			case "{original_rcpt_to}":
-				return msgMeta.OriginalRcpts[rcptTo]
+				oldestOriginalRcpt := rcptTo
+				for originalRcpt, ok := rcptTo, true; ok; originalRcpt, ok = msgMeta.OriginalRcpts[originalRcpt] {
+					oldestOriginalRcpt = originalRcpt
+				}
+				return oldestOriginalRcpt
 			case "{account_name}":
 				return accountName
 			}

--- a/internal/imap_filter/command/command.go
+++ b/internal/imap_filter/command/command.go
@@ -49,7 +49,7 @@ type Check struct {
 }
 
 func (c *Check) IMAPFilter(accountName string, rcptTo string, msgMeta *module.MsgMetadata, hdr textproto.Header, body buffer.Buffer) (folder string, flags []string, err error) {
-	cmd, args := c.expandCommand(msgMeta, accountName, rcptTo)
+	cmd, args := c.expandCommand(msgMeta, accountName, rcptTo, hdr)
 
 	var buf bytes.Buffer
 	_ = textproto.WriteHeader(&buf, hdr)
@@ -95,7 +95,7 @@ func (c *Check) Init(cfg *config.Map) error {
 	return err
 }
 
-func (c *Check) expandCommand(msgMeta *module.MsgMetadata, accountName string, rcptTo string) (string, []string) {
+func (c *Check) expandCommand(msgMeta *module.MsgMetadata, accountName string, rcptTo string, hdr textproto.Header) (string, []string) {
 	expArgs := make([]string, len(c.cmdArgs))
 
 	for i, arg := range c.cmdArgs {
@@ -144,6 +144,8 @@ func (c *Check) expandCommand(msgMeta *module.MsgMetadata, accountName string, r
 					oldestOriginalRcpt = originalRcpt
 				}
 				return oldestOriginalRcpt
+			case "{subject}":
+				return hdr.Get("Subject")
 			case "{account_name}":
 				return accountName
 			}

--- a/internal/imap_filter/command/command.go
+++ b/internal/imap_filter/command/command.go
@@ -128,9 +128,9 @@ func (c *Check) expandCommand(msgMeta *module.MsgMetadata, accountName string) (
 				valI, err := msgMeta.Conn.RDNSName.Get()
 				if err != nil {
 					return ""
-				}x
+				}
 				if valI == nil {
-					return ""x
+					return ""
 				}
 				return valI.(string)
 			case "{msg_id}":

--- a/internal/imap_filter/group.go
+++ b/internal/imap_filter/group.go
@@ -44,7 +44,7 @@ func NewGroup(_, instName string, _, _ []string) (module.Module, error) {
 	}, nil
 }
 
-func (g *Group) IMAPFilter(accountName string, meta *module.MsgMetadata, hdr textproto.Header, body buffer.Buffer) (folder string, flags []string, err error) {
+func (g *Group) IMAPFilter(accountName string, rcptTo string, meta *module.MsgMetadata, hdr textproto.Header, body buffer.Buffer) (folder string, flags []string, err error) {
 	if g == nil {
 		return "", nil, nil
 	}
@@ -53,7 +53,7 @@ func (g *Group) IMAPFilter(accountName string, meta *module.MsgMetadata, hdr tex
 		finalFlags  = make([]string, 0, len(g.Filters))
 	)
 	for _, f := range g.Filters {
-		folder, flags, err := f.IMAPFilter(accountName, meta, hdr, body)
+		folder, flags, err := f.IMAPFilter(accountName, rcptTo, meta, hdr, body)
 		if err != nil {
 			g.log.Error("IMAP filter failed", err)
 			continue

--- a/internal/msgpipeline/msgpipeline.go
+++ b/internal/msgpipeline/msgpipeline.go
@@ -338,8 +338,9 @@ func (dd *msgpipelineDelivery) AddRcpt(ctx context.Context, to string) error {
 		})
 	}
 
-	//Always setting so it can be retrieved by imap_filter
-	dd.msgMeta.OriginalRcpts[to] = originalTo
+	if originalTo != to {
+		dd.msgMeta.OriginalRcpts[to] = originalTo
+	}
 
 	for _, tgt := range rcptBlock.targets {
 		// Do not wrap errors coming from nested pipeline target delivery since

--- a/internal/msgpipeline/msgpipeline.go
+++ b/internal/msgpipeline/msgpipeline.go
@@ -338,9 +338,8 @@ func (dd *msgpipelineDelivery) AddRcpt(ctx context.Context, to string) error {
 		})
 	}
 
-	if originalTo != to {
-		dd.msgMeta.OriginalRcpts[to] = originalTo
-	}
+	//Always setting so it can be retrieved by imap_filter
+	dd.msgMeta.OriginalRcpts[to] = originalTo
 
 	for _, tgt := range rcptBlock.targets {
 		// Do not wrap errors coming from nested pipeline target delivery since

--- a/internal/storage/imapsql/delivery.go
+++ b/internal/storage/imapsql/delivery.go
@@ -32,7 +32,7 @@ import (
 	"github.com/foxcpp/maddy/internal/target"
 )
 
-type addecRcpt struct {
+type addedRcpt struct {
 	rcptTo string
 }
 type delivery struct {
@@ -41,7 +41,7 @@ type delivery struct {
 	d        imapsql.Delivery
 	mailFrom string
 
-	addedRcpts map[string]addecRcpt
+	addedRcpts map[string]addedRcpt
 }
 
 func (d *delivery) String() string {
@@ -92,7 +92,7 @@ func (d *delivery) AddRcpt(ctx context.Context, rcptTo string) error {
 		return err
 	}
 
-	d.addedRcpts[accountName] = addecRcpt{
+	d.addedRcpts[accountName] = addedRcpt{
 		rcptTo: rcptTo,
 	}
 	return nil
@@ -162,6 +162,6 @@ func (store *Storage) Start(ctx context.Context, msgMeta *module.MsgMetadata, ma
 		msgMeta:    msgMeta,
 		mailFrom:   mailFrom,
 		d:          store.Back.NewDelivery(),
-		addedRcpts: map[string]addecRcpt{},
+		addedRcpts: map[string]addedRcpt{},
 	}, nil
 }


### PR DESCRIPTION
I added the missing rcpts and address as in the check commands. This helps me to filter based on the original recipe of the email which I expect to change less than the sender.