### PR TITLE
bugfix: invert path check

### DIFF
--- a/internal/auth/dovecot_sasl/dovecot_sasl.go
+++ b/internal/auth/dovecot_sasl/dovecot_sasl.go
@@ -101,7 +101,7 @@ func (a *Auth) Init(cfg *config.Map) error {
 	if err != nil {
 		return fmt.Errorf("%s: invalid server endpoint: %v", modName, err)
 	}
-	if endp.Path == "" {
+	if endp.Path != "" {
 		return fmt.Errorf("%s: unexpected path in endpoint ", modName)
 	}
 


### PR DESCRIPTION
Hi i found this bug when trying to use dovecot_sasl on a remote host.

