### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/internal/modify/dkim/dkim_test.go
+++ b/internal/modify/dkim/dkim_test.go
@@ -22,7 +22,6 @@ import (
 	"bytes"
 	"context"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -167,11 +166,7 @@ func TestGenerateSignVerify(t *testing.T) {
 	test := func(domains []string, envelopeFrom string, expectDomain []string, keyAlgo string, headerCanon, bodyCanon dkim.Canonicalization, reload bool) {
 		t.Helper()
 
-		dir, err := ioutil.TempDir("", "maddy-tests-dkim-")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.RemoveAll(dir)
+		dir := t.TempDir()
 
 		m := newTestModifier(t, dir, keyAlgo, domains)
 		m.bodyCanon = bodyCanon

--- a/internal/modify/dkim/keys_test.go
+++ b/internal/modify/dkim/keys_test.go
@@ -23,7 +23,6 @@ import (
 	"crypto/rsa"
 	"encoding/base64"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -35,11 +34,7 @@ func TestKeyLoad_new(t *testing.T) {
 	m := Modifier{}
 	m.log = testutils.Logger(t, m.Name())
 
-	dir, err := ioutil.TempDir("", "maddy-tests-dkim-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	signer, newKey, err := m.loadOrGenerateKey(filepath.Join(dir, "testkey.key"), "ed25519")
 	if err != nil {
@@ -85,11 +80,7 @@ func TestKeyLoad_existing_pkcs8(t *testing.T) {
 	m := Modifier{}
 	m.log = testutils.Logger(t, m.Name())
 
-	dir, err := ioutil.TempDir("", "maddy-tests-dkim-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	if err := ioutil.WriteFile(filepath.Join(dir, "testkey.key"), []byte(pkeyEd25519), 0o600); err != nil {
 		t.Fatal(err)
@@ -141,11 +132,7 @@ func TestKeyLoad_existing_pkcs1(t *testing.T) {
 	m := Modifier{}
 	m.log = testutils.Logger(t, m.Name())
 
-	dir, err := ioutil.TempDir("", "maddy-tests-dkim-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	if err := ioutil.WriteFile(filepath.Join(dir, "testkey.key"), []byte(pkeyRSA), 0o600); err != nil {
 		t.Fatal(err)

--- a/internal/target/queue/queue_test.go
+++ b/internal/target/queue/queue_test.go
@@ -45,20 +45,13 @@ import (
 // See newTestQueueDir to create testing queue from an existing directory.
 // It is called responsibility to remove queue directory created by this function.
 func newTestQueue(t *testing.T, target module.DeliveryTarget) *Queue {
-	dir, err := ioutil.TempDir("", "maddy-tests-queue")
-	if err != nil {
-		t.Fatal("failed to create temporary directory for queue:", err)
-	}
-	return newTestQueueDir(t, target, dir)
+	return newTestQueueDir(t, target, t.TempDir())
 }
 
 func cleanQueue(t *testing.T, q *Queue) {
 	t.Log("--- queue.Close")
 	if err := q.Close(); err != nil {
 		t.Fatal("queue.Close:", err)
-	}
-	if err := os.RemoveAll(q.location); err != nil {
-		t.Fatal("os.RemoveAll", err)
 	}
 }
 

--- a/tests/dovecot_sasl_test.go
+++ b/tests/dovecot_sasl_test.go
@@ -103,10 +103,7 @@ func runDovecot(t *testing.T) (string, *exec.Cmd) {
 		t.Fatal(err)
 	}
 
-	tempDir, err := ioutil.TempDir("", "maddy-dovecot-interop-")
-	if err != nil {
-		t.Fatal(err)
-	}
+	tempDir := t.TempDir()
 
 	curUser, err := user.Current()
 	if err != nil {

--- a/tests/dovecot_sasld_test.go
+++ b/tests/dovecot_sasld_test.go
@@ -88,16 +88,13 @@ Xi3olS9rB0J+Rvjz
 -----END PRIVATE KEY-----`
 
 func runChasquid(t *testing.T, authClientPath string) (string, *exec.Cmd) {
-	tempDir, err := ioutil.TempDir("", "maddy-chasquid-interop-")
-	if err != nil {
-		t.Fatal(err)
-	}
+	tempDir := t.TempDir()
 	t.Log("Using", tempDir)
 
 	chasquidConf := strings.NewReplacer(
 		"$ROOT", tempDir,
 		"$AUTH_CLIENT", authClientPath).Replace(chasquidConf)
-	err = ioutil.WriteFile(filepath.Join(tempDir, "chasquid.conf"), []byte(chasquidConf), os.ModePerm)
+	err := ioutil.WriteFile(filepath.Join(tempDir, "chasquid.conf"), []byte(chasquidConf), os.ModePerm)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
A small testing enhancement here.

We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete.

Reference: https://pkg.go.dev/testing#T.TempDir