### PR TITLE
Move closing the default logger after printing configuration errors

### DIFF
--- a/maddy.go
+++ b/maddy.go
@@ -161,6 +161,8 @@ func Run() int {
 		return 2
 	}
 
+	defer log.DefaultLogger.Out.Close()
+
 	if err := moduleMain(cfg); err != nil {
 		systemdStatusErr(err)
 		log.Println(err)
@@ -270,8 +272,6 @@ func moduleMain(cfg []config.Node) error {
 	if err := InitDirs(); err != nil {
 		return err
 	}
-
-	defer log.DefaultLogger.Out.Close()
 
 	hooks.AddHook(hooks.EventLogRotate, reinitLogging)
 


### PR DESCRIPTION
As it's being used in maddy.go:166, it can't be closed before that, otherwise the error doesn't get printed anywhere:
https://github.com/foxcpp/maddy/blob/4b1c4f932a38557fbb0adeab9f8d28ec672216ca/maddy.go#L166


Closes #482 