### PR TITLE
Fix issue with `maddyctl hash`

### DIFF
--- a/cmd/maddyctl/hash.go
+++ b/cmd/maddyctl/hash.go
@@ -65,7 +65,7 @@ func hashCommand(ctx *cli.Context) error {
 		opts.Argon2Memory = uint32(ctx.Int("argon2-memory"))
 	}
 	if ctx.IsSet("argon2-time") {
-		opts.Argon2Memory = uint32(ctx.Int("argon2-time"))
+		opts.Argon2Time = uint32(ctx.Int("argon2-time"))
 	}
 	if ctx.IsSet("argon2-threads") {
 		opts.Argon2Threads = uint8(ctx.Int("argon2-threads"))


### PR DESCRIPTION
--argon2-time set the memory instead of time due to a typo