### PR TITLE
Remove references to man.5 from build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -104,9 +104,6 @@ build_man_pages() {
 	for f in ./docs/man/*.1.scd; do
 		scdoc < "$f" > "${builddir}/man/$(basename "$f" .scd)"
 	done
-	for f in ./docs/man/*.5.scd; do
-		scdoc < "$f" > "${builddir}/man/$(basename "$f" .scd)"
-	done
 }
 
 build() {
@@ -158,10 +155,6 @@ install() {
 		command install -m 0755 -d "${destdir}/${prefix}/share/man/man1/"
 		for f in "${builddir}"/man/*.1; do
 			command install -m 0644 "$f" "${destdir}/${prefix}/share/man/man1/"
-		done
-		command install -m 0755 -d "${destdir}/${prefix}/share/man/man5/"
-		for f in "${builddir}"/man/*.5; do
-			command install -m 0644 "$f" "${destdir}/${prefix}/share/man/man5/"
 		done
 	fi
 }


### PR DESCRIPTION
man.5 page was removed in c0eacfa0f34f4040ec4fd5d3ca44a35e8cde21b4
removed remaining references in build.sh, otherwise strict build (like arch linux makepkg) fails.