### PR TITLE
fix goroutine "leak" in openmetrics

### DIFF
--- a/internal/endpoint/openmetrics/om.go
+++ b/internal/endpoint/openmetrics/om.go
@@ -80,6 +80,7 @@ func (e *Endpoint) Init(cfg *config.Map) error {
 			if err != nil && !errors.Is(err, http.ErrServerClosed) {
 				e.logger.Error("serve failed", err, "endpoint", a)
 			}
+			e.listenersWg.Done()
 		}()
 	}
 


### PR DESCRIPTION
make graceful shutdown when openmetrics endpoint is enable