### PR TITLE
fix: typo

### DIFF
--- a/internal/target/remote/connect.go
+++ b/internal/target/remote/connect.go
@@ -238,7 +238,7 @@ func (rd *remoteDelivery) connectionForDomain(ctx context.Context, domain string
 			return nil, &exterrors.SMTPError{
 				Code:         550,
 				EnhancedCode: exterrors.EnhancedCode{5, 7, 30},
-				Message:      "Failed to estabilish the MX record authenticity (REQUIRETLS)",
+				Message:      "Failed to establish the MX record authenticity (REQUIRETLS)",
 				Misc: map[string]interface{}{
 					"mx_level": conn.mxLevel,
 				},

--- a/internal/target/remote/security.go
+++ b/internal/target/remote/security.go
@@ -180,7 +180,7 @@ func (c *mtastsDelivery) CheckMX(ctx context.Context, mxLevel module.MXLevel, do
 			return module.MXNone, &exterrors.SMTPError{
 				Code:         550,
 				EnhancedCode: exterrors.EnhancedCode{5, 7, 0},
-				Message:      "Failed to estabilish the module.MX record authenticity (MTA-STS)",
+				Message:      "Failed to establish the module.MX record authenticity (MTA-STS)",
 			}
 		}
 		c.log.Msg("MX does not match published non-enforced MTA-STS policy", "mx", mx, "domain", c.domain)
@@ -608,7 +608,7 @@ func (l localPolicy) CheckMX(ctx context.Context, mxLevel module.MXLevel, domain
 			// a temporary error (we can't know with the current design).
 			Code:         451,
 			EnhancedCode: exterrors.EnhancedCode{4, 7, 0},
-			Message:      "Failed to estabilish the module.MX record authenticity",
+			Message:      "Failed to establish the module.MX record authenticity",
 			Misc: map[string]interface{}{
 				"mx_level": mxLevel,
 			},


### PR DESCRIPTION
```estabilish``` -> ```establish```