### PR TITLE
Doc: Update imapsql.md

### DIFF
--- a/docs/reference/storage/imapsql.md
+++ b/docs/reference/storage/imapsql.md
@@ -4,7 +4,7 @@ The imapsql module implements database for IMAP index and message
 metadata using SQL-based relational database.
 
 Message contents are stored in an "blob store" defined by msg\_store
-directive. By default this is a file system directory under /var/lib/maddy.
+directive. By default this is a file system directory under /data/messages.
 
 Supported RDBMS:
 - SQLite 3.25.0


### PR DESCRIPTION
From the actual behaviour I deduct that messages are stored under /data/messages, and this doc must be outdated?