### PR TITLE
Clone tlsCfg with ServerName because ServerName is needed by StartTLS

### DIFF
--- a/internal/auth/ldap/ldap.go
+++ b/internal/auth/ldap/ldap.go
@@ -147,8 +147,8 @@ func (a *Auth) newConn() (*ldap.Conn, error) {
 			return nil, fmt.Errorf("auth.ldap: invalid server URL: %w", err)
 		}
 		hostname := parsedURL.Host
+		a.tlsCfg.ServerName = strings.Split(hostname, ":")[0]
 		tlsCfg = a.tlsCfg.Clone()
-		a.tlsCfg.ServerName = hostname
 
 		conn, err = ldap.DialURL(u, ldap.DialWithDialer(a.dialer), ldap.DialWithTLSConfig(tlsCfg))
 		if err != nil {


### PR DESCRIPTION
When `starttls` is set to true, the following error happens.
```
auth.ldap: LDAP Result Code 200 "Network Error": TLS handshake failed (tls: either ServerName or InsecureSkipVerify must be specified in the tls.Config)
```
And using `hostname`(Domain:Port) as ServerName still gets another error, and the Domain is only be needed.
```
auth.ldap: LDAP Result Code 200 "Network Error": TLS handshake failed (EOF)
```