### PR TITLE
Update docker.md

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -72,4 +72,4 @@ docker run \
 
 It will fail on first startup. Copy TLS certificate to /data/tls/fullchain.pem
 and key to /data/tls/privkey.pem. Run the server again. Finish DNS configuration
-(DKIM keys, etc) as described in [tutorials/setting-up/](tutorials/setting-up/).
+(DKIM keys, etc) as described in [tutorials/setting-up/](../tutorials/setting-up/).


### PR DESCRIPTION
https://maddy.email/docker/

Should fix following:

`It will fail on first startup. Copy TLS certificate to /data/tls/fullchain.pem and key to /data/tls/privkey.pem. Run the server again. Finish DNS configuration (DKIM keys, etc) as described in [tutorials/setting-up/](https://maddy.email/docker/tutorials/setting-up/).`

```
This maddy.email page can’t be found
No webpage was found for the web address: https://maddy.email/docker/tutorials/setting-up/
HTTP ERROR 404
```