### PR TITLE
fix(f2b): use correct retry directive

### DIFF
--- a/dist/fail2ban/jail.d/maddy-dictonary-attack.conf
+++ b/dist/fail2ban/jail.d/maddy-dictonary-attack.conf
@@ -2,6 +2,6 @@
 port     = 993,465,25
 filter   = maddy-dictonary-attack
 bantime  = 72h
-maxtries = 3
+maxretry = 3
 findtime = 6h
 backend  = systemd


### PR DESCRIPTION
`maxtries` is not a valid option for f2b jails, `maxretry` is. 
[proof](https://github.com/fail2ban/fail2ban/blob/e1d3006b0330e9777705a7baafe3989d442ed120/config/jail.conf#L107)