### PR TITLE
fix(session): detect canceled lookup correctly

### DIFF
--- a/internal/endpoint/smtp/session.go
+++ b/internal/endpoint/smtp/session.go
@@ -319,13 +319,13 @@ func (s *Session) fetchRDNSName(ctx context.Context) {
 			return
 		}
 
-		reason, misc := exterrors.UnwrapDNSErr(err)
-		misc["reason"] = reason
-		if !strings.HasSuffix(reason, "canceled") {
+		if !errors.Is(err, context.Canceled) {
 			// Often occurs when transaction completes before rDNS lookup and
 			// rDNS name was not actually needed. So do not log cancelation
 			// error if that's the case.
 
+			reason, misc := exterrors.UnwrapDNSErr(err)
+			misc["reason"] = reason
 			s.log.Error("rDNS error", exterrors.WithFields(err, misc), "src_ip", s.connState.RemoteAddr)
 		}
 		s.connState.RDNSName.Set(nil, err)


### PR DESCRIPTION
Hi, this will prevent `smtp: rDNS error	{"reason":"","src_ip":"x.x.x.x:port"}` for every incoming message.
Weirdly, it didn't start appearing before using milter/rspamd. It should be fixed regardless, but I don't really know what changed. Maybe timeout expiring while waiting for rspamd response? Or rspamd hogging DNS resolver time for it's own checks.
