### PR TITLE
Fix wrong DNS query type in DANE lookups for IPv6-only hosts

### DIFF
--- a/framework/dns/dnssec.go
+++ b/framework/dns/dnssec.go
@@ -229,7 +229,7 @@ func (e ExtResolver) CheckCNAMEAD(ctx context.Context, host string) (ad bool, rn
 	if rname == "" {
 		// IPv6-only host? Try to find out rname using AAAA lookup.
 		msg := new(dns.Msg)
-		msg.SetQuestion(dns.Fqdn(host), dns.TypeA)
+		msg.SetQuestion(dns.Fqdn(host), dns.TypeAAAA)
 		msg.SetEdns0(4096, false)
 		msg.AuthenticatedData = true
 		resp, err := e.exchange(ctx, msg)


### PR DESCRIPTION
An apparent typo. This should fix #631.

The patch is tested on top of v0.7.