### PR TITLE
Correct spf dns record

### DIFF
--- a/docs/tutorials/setting-up.md
+++ b/docs/tutorials/setting-up.md
@@ -168,7 +168,7 @@ mx1.example.org.   AAAA  2001:beef::1
 ; for this domain, and nobody else.
 example.org.     TXT   "v=spf1 mx ~all"
 ; It is recommended to server SPF record for both domain and MX hostname
-mx1.example.org. TXT   "v=spf1 mx ~all"
+mx1.example.org. TXT   "v=spf1 a ~all"
 
 ; Opt-in into DMARC with permissive policy and request reports about broken
 ; messages.


### PR DESCRIPTION
Based on the spf documnet: 
http://www.open-spf.org/action_browse_id_FAQ/Common_mistakes_revision_26/#helo
```
example.com.             IN  TXT  "v=spf1 mx -all"
mailserver.example.com.  IN  TXT  "v=spf1 a -all"
```
the second spf record in doc should set to a record. otherwise the mail-tester will show 
```
SPF_HELO_SOFTFAIL		SPF: HELO does not match SPF record (softfail)
```
softfail