### PR TITLE
fix: bump alpine to 3.18.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN mkdir -p /pkg/data && \
     cp maddy.conf.docker /pkg/data/maddy.conf && \
     ./build.sh --builddir /tmp --destdir /pkg/ --tags docker build install
 
-FROM alpine:3.17.0
+FROM alpine:3.18.4
 LABEL maintainer="fox.cpp@disroot.org"
 LABEL org.opencontainers.image.source=https://github.com/foxcpp/maddy
 


### PR DESCRIPTION
I am not sure if you want this to be `alpine:3.18` instead, feel free to change it.