### PR TITLE
docs/reference/modifiers/dkim: fix number of sigs for sign_fields

### DIFF
--- a/docs/reference/modifiers/dkim.md
+++ b/docs/reference/modifiers/dkim.md
@@ -121,7 +121,7 @@ Default set of oversigned fields:
 ### sign_fields _list..._
 Default: see below
 
-Header fields that should be signed n+1 times where n is times they are
+Header fields that should be signed n times where n is times they are
 present in the message. For these fields, additional values can be prepended
 by intermediate relays, but existing values can't be changed.
 


### PR DESCRIPTION
oversign_fields is signed n+1 times, but sign_fields only n times.