### PR TITLE
(maybe) Fixes a typo in the `rspamd` docs

### DIFF
--- a/docs/third-party/rspamd.md
+++ b/docs/third-party/rspamd.md
@@ -7,7 +7,7 @@ If rspamd is running locally, it is enough to just add `rspamd` check
 with default configuration into appropriate check block (probably in
 local_routing):
 ```
-checks {
+check {
     ...
     rspamd
 }


### PR DESCRIPTION
Currently, to add _rspamd_, [the docs ](https://maddy.email/third-party/rspamd/) suggest to

> add rspamd check with default configuration into appropriate check block (probably in local_routing):
> ```
> checks {
>    ...
>    rspamd
> }```
>

Adding this block in `local_routing` results in a failure to start, because in this context only `check` is valid.

(I see that `checks` exist at top-level, but if we mention `local_routing` and appropriate `check` block, it makes more sense to me that the code block is also `check`)