### PR TITLE
build: make "./build.sh install" reusable

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,6 +3,7 @@
 destdir=/
 builddir="$PWD/build"
 prefix=/usr/local
+configdir="${destdir}etc/maddy"
 version=
 static=0
 if [ "${GOFLAGS}" = "" ]; then
@@ -139,9 +140,18 @@ install() {
 
 	command install -m 0755 -d "${destdir}/${prefix}/bin/"
 	command install -m 0755 "${builddir}/maddy" "${destdir}/${prefix}/bin/"
-	command ln -s maddy "${destdir}/${prefix}/bin/maddyctl"
-	command install -m 0755 -d "${destdir}/etc/maddy/"
-	command install -m 0644 ./maddy.conf "${destdir}/etc/maddy/maddy.conf"
+	command ln -sf maddy "${destdir}/${prefix}/bin/maddyctl"
+	command install -m 0755 -d "${configdir}"
+
+
+	# We do not want to overwrite existing configuration.
+	# If the file exists, then save it with .default suffix and warn user.
+	if [ ! -e "${configdir}/maddy.conf" ]; then
+		command install -m 0644 ./maddy.conf "${configdir}/maddy.conf"
+	else
+		echo "-- [!] Configuration file ${configdir}/maddy.conf exists, saving to ${configdir}/maddy.conf.default" >&2
+		command install -m 0644 ./maddy.conf "${configdir}/maddy.conf.default"
+	fi
 
 	# Attempt to install systemd units only for Linux.
 	# Check is done using GOOS instead of uname -s to account for possible
@@ -150,19 +160,19 @@ install() {
 	# with sudo and go installation is user-specific, so fallback
 	# to using uname -s in the end.
 	set +e
-  if command -v go >/dev/null 2>/dev/null; then
-    set -e
-    if [ "$(go env GOOS)" = "linux" ]; then
-    		command install -m 0755 -d "${destdir}/${prefix}/lib/systemd/system/"
-    		command install -m 0644 "${builddir}"/systemd/*.service "${destdir}/${prefix}/lib/systemd/system/"
-    fi
-  else
-    set -e
-    if [ "$(uname -s)" = "Linux" ]; then
-        		command install -m 0755 -d "${destdir}/${prefix}/lib/systemd/system/"
-        		command install -m 0644 "${builddir}"/systemd/*.service "${destdir}/${prefix}/lib/systemd/system/"
-        fi
-  fi
+	if command -v go >/dev/null 2>/dev/null; then
+		set -e
+		if [ "$(go env GOOS)" = "linux" ]; then
+			command install -C -m 0755 -d "${destdir}/${prefix}/lib/systemd/system/"
+			command install -C -m 0644 "${builddir}"/systemd/*.service "${destdir}/${prefix}/lib/systemd/system/"
+		fi
+	else
+		set -e
+		if [ "$(uname -s)" = "Linux" ]; then
+			command install -C -m 0755 -d "${destdir}/${prefix}/lib/systemd/system/"
+			command install -C -m 0644 "${builddir}"/systemd/*.service "${destdir}/${prefix}/lib/systemd/system/"
+		fi
+	fi
 
 	if [ -e "${builddir}"/man ]; then
 		command install -m 0755 -d "${destdir}/${prefix}/share/man/man1/"


### PR DESCRIPTION
* prevent the script from blindly overwriting the current configuration
* force maddyctl symbolic linking
* fix indentation in build.sh

Few days ago I learned the hard way, that running `./build.sh install` on existing installation of maddy blindly overwrites the configuration. This commit alters the bahevior of `build.sh` to not blindly copy over existing `maddy.conf` and force the creation of the `maddyctl` symlink so that the script can be used to update current installation.