### PR TITLE
Add additional build tags to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM golang:1.19-alpine AS build-env
 
+ARG ADDITIONAL_BUILD_TAGS=""
+
 RUN set -ex && \
     apk upgrade --no-cache --available && \
     apk add --no-cache build-base
@@ -12,7 +14,7 @@ RUN go mod download
 COPY . ./
 RUN mkdir -p /pkg/data && \
     cp maddy.conf.docker /pkg/data/maddy.conf && \
-    ./build.sh --builddir /tmp --destdir /pkg/ --tags docker build install
+    ./build.sh --builddir /tmp --destdir /pkg/ --tags "docker ${ADDITIONAL_BUILD_TAGS}" build install
 
 FROM alpine:3.18.4
 LABEL maintainer="fox.cpp@disroot.org"

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -54,6 +54,11 @@ command. One way to it is to run it using `docker exec` instead of `docker run`:
 docker exec -it container_name_here maddy creds create foxcpp@maddy.test
 ```
 
+## Build Tags
+
+Some Maddy features (such as automatic certificate management via ACME with [a non-default libdns provider](../reference/tls-acme/#dns-providers)) require build tags to be passed to Maddy's `build.sh`, as this is run in the Dockerfile you must compile your own Docker image. Build tags can be set via the docker build argument `ADDITIONAL_BUILD_TAGS` e.g. `docker build --build-arg ADDITIONAL_BUILD_TAGS="libdns_acmedns libdns_route53" -t yourorgname/maddy:yourtagname .`.
+
+
 ## TL;DR
 
 ```


### PR DESCRIPTION
This PR adds support for passing additional tags to the `./build.sh` inside the `Dockerfile` at build time.

Use case, as per the docs I've added, is to be able to get more libdns providers in there (like #689)