### PR TITLE
cfgparser: add env_split for splitting of ENV variable values on comma 

### DIFF
--- a/docs/reference/config-syntax.md
+++ b/docs/reference/config-syntax.md
@@ -87,6 +87,16 @@ directive0 {env:VAR}
 Parse is forgiving and incomplete variable placeholder (e.g. '{env:VAR') will
 be left as-is. Variables are expanded inside quotes too.
 
+Environment values that are comma separated can optionally be split to space separated strings using {env_split:COMMA_SEPARATED_VARIABLE_NAME}
+
+```
+# SEP_VAR=foo,bar,baz
+
+directive1 {env_split:SEP_VAR}
+```
+
+In this usage the value of `directive1` would be `foo bar baz` (and `{env:SEP_VAR}` would be `foo,bar,baz`)
+
 ## Snippets & imports
 
 You can reuse blocks of configuration by defining them as "snippets". Snippet
@@ -196,5 +206,3 @@ No-op module. It doesn't need to be configured explicitly and can be referenced
 using "dummy" name. It can act as a delivery target or auth.
 provider. In the latter case, it will accept any credentials, allowing any
 client to authenticate using any username and password (use with care!).
-
-

--- a/framework/cfgparser/parse_test.go
+++ b/framework/cfgparser/parse_test.go
@@ -343,6 +343,47 @@ var cases = []struct {
 		false,
 	},
 	{
+		"environment variable split at comma expansion",
+		`a {env_split:TESTING_VARIABLE_SPLIT}`,
+		[]Node{
+			{
+				Name:     "a",
+				Args:     []string{"value1", "value2", "value3"},
+				Children: nil,
+				File:     "test",
+				Line:     1,
+			},
+		},
+		false,
+	},
+	{
+		"environment variable mixed usage",
+		`mixed {env:TESTING_VARIABLE} {env_split:TESTING_VARIABLE_SPLIT}`,
+		[]Node{
+			{
+				Name:     "mixed",
+				Args:     []string{"ABCDEF", "value1", "value2", "value3"},
+				Children: nil,
+				File:     "test",
+				Line:     1,
+			},
+		},
+		false,
+	},
+	{
+		"environment variable not split on comma",
+		`not_split {env:TESTING_VARIABLE_SPLIT}`,
+		[]Node{
+			{
+				Name: "not_split",
+				Args: []string{"value1,value2,value3"},
+				File: "test",
+				Line: 1,
+			},
+		},
+		false,
+	},
+	{
 		"snippet expansion",
 		`(foo) { a }
 		 import foo`,
@@ -581,6 +622,7 @@ func printTree(t *testing.T, root Node, indent int) {
 func TestRead(t *testing.T) {
 	os.Setenv("TESTING_VARIABLE", "ABCDEF")
 	os.Setenv("TESTING_VARIABLE2", "ABC2 DEF2")
+	os.Setenv("TESTING_VARIABLE_SPLIT", "value1,value2,value3")
 
 	for _, case_ := range cases {
 		case_ := case_


### PR DESCRIPTION
This PR adds a new config placeholder syntax, `{env_split:VAR_NAME}`, alongside the existing `{env:VAR_NAME}`

* `{env:VAR_NAME}`: Substitutes the value of the environment variable `VAR_NAME` as is, preserving its format, including any commas.
* `{env_split:VAR_NAME}`: Substitutes the value of the environment variable `VAR_NAME`, converting any commas in the value into spaces. This is particularly useful for configurations that expect space-separated lists but are populated from environment variables that naturally format such lists as comma-separated strings.

The use case of `$(local_domains) = $(primary_domain) example.com` multiple domains in Docker can now use this feature by setting an environment variable with a value like `domain1.com,domain2.com`. Using `{env_split:OTHER_DOMAINS}` will automatically convert this to `domain1.com domain2.com`, fitting into configurations that require space-separated values.

I have also added test cases for splitting, not split and mixing both.