### PR TITLE
#736: dmarc evalute added check if fromDomain is a TLD

### DIFF
--- a/internal/dmarc/evaluate.go
+++ b/internal/dmarc/evaluate.go
@@ -207,6 +207,10 @@ func isAligned(fromDomain, authDomain string, mode AlignmentMode) bool {
 		return strings.EqualFold(fromDomain, authDomain)
 	}
 
+	tld, _ := publicsuffix.PublicSuffix(fromDomain)
+	if strings.EqualFold(fromDomain, tld) {
+		return strings.EqualFold(fromDomain, authDomain)
+	}
 	orgDomainFrom, err := publicsuffix.EffectiveTLDPlusOne(fromDomain)
 	if err != nil {
 		return false


### PR DESCRIPTION
fixes the use of a TLD with DMARC DKIM policy relaxed 