### PR TITLE
fix: correctly announce SASL LOGIN capabilty

### DIFF
--- a/internal/auth/sasl.go
+++ b/internal/auth/sasl.go
@@ -62,7 +62,7 @@ func (s *SASLAuth) SASLMechanisms() []string {
 
 	if len(s.Plain) != 0 {
 		mechs = append(mechs, sasl.Plain)
-		if s.OnlyFirstID {
+		if s.EnableLogin {
 			mechs = append(mechs, sasl.Login)
 		}
 	}


### PR DESCRIPTION
This PR corrects the test for announcing SASL LOGIN support. Resolves foxcpp/maddy#761.