### PR TITLE
Implement maddy_queue_length metric

### DIFF
--- a/internal/endpoint/smtp/metrics.go
+++ b/internal/endpoint/smtp/metrics.go
@@ -26,7 +26,7 @@ var (
 			Namespace: "maddy",
 			Subsystem: "smtp",
 			Name:      "started_transactions",
-			Help:      "Amount of SMTP trasanactions started",
+			Help:      "Amount of SMTP transactions started",
 		},
 		[]string{"module"},
 	)
@@ -35,7 +35,7 @@ var (
 			Namespace: "maddy",
 			Subsystem: "smtp",
 			Name:      "smtp_completed_transactions",
-			Help:      "Amount of SMTP trasanactions successfully completed",
+			Help:      "Amount of SMTP transactions successfully completed",
 		},
 		[]string{"module"},
 	)
@@ -44,7 +44,7 @@ var (
 			Namespace: "maddy",
 			Subsystem: "smtp",
 			Name:      "aborted_transactions",
-			Help:      "Amount of SMTP trasanactions aborted",
+			Help:      "Amount of SMTP transactions aborted",
 		},
 		[]string{"module"},
 	)


### PR DESCRIPTION
The maddy_queue_length was already registered but never used.

The gauge is updated when actions on disks are performed:

- Incremented when a message is written to disk or when the queue
is read from disk.
- Decremented when a message is removed from disk.