### PR TITLE
fix: reduce StaleKeyLifetimeSec to 4 minutes

### DIFF
--- a/internal/target/remote/remote.go
+++ b/internal/target/remote/remote.go
@@ -146,7 +146,7 @@ func (rt *Target) Init(cfg *config.Map) error {
 		MaxKeys:             5000,
 		MaxConnsPerKey:      5,      // basically, max. amount of idle connections in cache
 		MaxConnLifetimeSec:  150,    // 2.5 mins, half of recommended idle time from RFC 5321
-		StaleKeyLifetimeSec: 60 * 5, // should be bigger than MaxConnLifetimeSec
+		StaleKeyLifetimeSec: 60 * 4, // make sure that cleanup runs before recommended idle time from RFC 5321
 	}
 	cfg.Int("conn_max_idle_count", false, false, 5, &poolCfg.MaxConnsPerKey)
 	cfg.Int64("conn_max_idle_time", false, false, 150, &poolCfg.MaxConnLifetimeSec)

--- a/internal/target/remote/remote_test.go
+++ b/internal/target/remote/remote_test.go
@@ -64,7 +64,7 @@ func testTarget(t *testing.T, zones map[string]mockdns.Zone, extResolver *dns.Ex
 			MaxKeys:             5000,
 			MaxConnsPerKey:      5,      // basically, max. amount of idle connections in cache
 			MaxConnLifetimeSec:  150,    // 2.5 mins, half of recommended idle time from RFC 5321
-			StaleKeyLifetimeSec: 60 * 5, // should be bigger than MaxConnLifetimeSec
+			StaleKeyLifetimeSec: 60 * 4, // make sure that cleanup runs before recommended idle time from RFC 5321
 		}),
 	}
 


### PR DESCRIPTION
RFC 5321 recommends idle time of 5 minutes. Maddy runs pool cleanup once per minute. When a connection is returned to the pool at time 'last cleanup + 10 seconds', it will be closed at 'last cleanup + StaleKeyLifetimeSec + 60 seconds' . With the original value of 5 minutes, the connection will be closed 50 seconds after the recommended timeout. By reducing the lifetime to 4 minutes, connections might be closed a little early, but never late.

Should fix #693 