### PR TITLE
feat(dnsbl): Add per-response-code scoring with custom messages

### DIFF
--- a/docs/reference/checks/dnsbl.md
+++ b/docs/reference/checks/dnsbl.md
@@ -216,7 +216,9 @@ and contains the following directives:
 **Required**
 
 Score to add when this response code is returned. If multiple response codes
-are returned by the DNSBL, scores are summed together.
+are returned by the DNSBL, and they match different rules, the scores from
+all matched rules are summed together. Each rule is counted only once, even
+if multiple returned IPs match networks within that rule.
 
 #### message _string_
 **Optional**
@@ -244,6 +246,12 @@ zen.spamhaus.org {
     }
 }
 ```
+
+**Scoring behavior:**
+- If DNSBL returns `127.0.0.2` only → Score: 10 (matches first rule)
+- If DNSBL returns `127.0.0.11` only → Score: 5 (matches second rule)
+- If DNSBL returns both `127.0.0.2` and `127.0.0.11` → Score: 15 (both rules match, scores sum)
+- If DNSBL returns both `127.0.0.2` and `127.0.0.3` → Score: 10 (same rule matches, counted once)
 
 **Backwards compatibility:** When `response` blocks are not used, the legacy
 `responses` and `score` directives work as before.

--- a/docs/reference/checks/dnsbl.md
+++ b/docs/reference/checks/dnsbl.md
@@ -207,6 +207,9 @@ Defines per-response-code rules for scoring and custom messages. This is useful
 for combined DNSBLs like Spamhaus ZEN that return different codes for different
 listing types.
 
+This works for both IP-based lookups (client_ipv4, client_ipv6) and domain-based
+lookups (ehlo, mailfrom).
+
 Each `response` block takes one or more IP addresses or CIDR ranges as arguments
 and contains the following directives:
 

--- a/docs/reference/checks/dnsbl.md
+++ b/docs/reference/checks/dnsbl.md
@@ -203,8 +203,6 @@ rules is used instead of this flat score value.
 
 ### response _ip..._
 
-**New in 0.8**
-
 Defines per-response-code rules for scoring and custom messages. This is useful
 for combined DNSBLs like Spamhaus ZEN that return different codes for different
 listing types.

--- a/internal/check/dnsbl/common.go
+++ b/internal/check/dnsbl/common.go
@@ -133,7 +133,7 @@ func matchResponseRules(addrs []net.IPAddr, rules []ResponseRule) (score int, me
 			if matchedRules[ruleIdx] {
 				continue
 			}
-			
+
 			for _, respNet := range rule.Networks {
 				if respNet.Contains(addr.IP) {
 					score += rule.Score
@@ -187,12 +187,12 @@ func checkIP(ctx context.Context, resolver dns.Resolver, cfg List, ip net.IP) er
 			return nil
 		}
 		score = matchedScore
-		
+
 		// Use first matched message if available
 		if len(matchedMessages) > 0 {
 			customMessage = matchedMessages[0]
 		}
-		
+
 		// Build filteredAddrs from matched reasons for TXT lookup fallback
 		for _, reason := range matchedReasons {
 			filteredAddrs = append(filteredAddrs, net.IPAddr{IP: net.ParseIP(reason)})

--- a/internal/check/dnsbl/dnsbl.go
+++ b/internal/check/dnsbl/dnsbl.go
@@ -373,14 +373,14 @@ func (bl *DNSBL) checkLists(ctx context.Context, ip net.IP, ehlo, mailFrom strin
 				defer lck.Unlock()
 				listedOn = append(listedOn, listErr.List)
 				reasons = append(reasons, listErr.Reason)
-				
+
 				// Use score from ListedErr if set (new behavior), otherwise use legacy ScoreAdj
 				if listErr.Score != 0 {
 					score += listErr.Score
 				} else {
 					score += list.ScoreAdj
 				}
-				
+
 				// Collect custom messages if available
 				if listErr.Message != "" {
 					messages = append(messages, listErr.Message)

--- a/internal/check/dnsbl/dnsbl.go
+++ b/internal/check/dnsbl/dnsbl.go
@@ -134,9 +134,7 @@ func (bl *DNSBL) readListCfg(node config.Node) error {
 	cfg.Bool("mailfrom", false, defaultBL.EHLO, &listCfg.MAILFROM)
 	cfg.Int("score", false, false, 1, &listCfg.ScoreAdj)
 	cfg.StringList("responses", false, false, []string{"127.0.0.1/24"}, &responseNets)
-	cfg.AllowUnknown()
-	unknown, err := cfg.Process()
-	if err != nil {
+	if _, err := cfg.Process(); err != nil {
 		return err
 	}
 
@@ -154,8 +152,8 @@ func (bl *DNSBL) readListCfg(node config.Node) error {
 		listCfg.Responses = append(listCfg.Responses, *ipNet)
 	}
 
-	// Parse response blocks
-	for _, child := range unknown {
+	// Parse response blocks from node children
+	for _, child := range node.Children {
 		if child.Name == "response" {
 			rule, err := parseResponseRule(child)
 			if err != nil {

--- a/internal/check/dnsbl/dnsbl.go
+++ b/internal/check/dnsbl/dnsbl.go
@@ -38,6 +38,12 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+type ResponseRule struct {
+	Networks []net.IPNet
+	Score    int
+	Message  string
+}
+
 type List struct {
 	Zone string
 
@@ -49,6 +55,8 @@ type List struct {
 
 	ScoreAdj  int
 	Responses []net.IPNet
+
+	ResponseRules []ResponseRule
 }
 
 var defaultBL = List{
@@ -126,7 +134,9 @@ func (bl *DNSBL) readListCfg(node config.Node) error {
 	cfg.Bool("mailfrom", false, defaultBL.EHLO, &listCfg.MAILFROM)
 	cfg.Int("score", false, false, 1, &listCfg.ScoreAdj)
 	cfg.StringList("responses", false, false, []string{"127.0.0.1/24"}, &responseNets)
-	if _, err := cfg.Process(); err != nil {
+	cfg.AllowUnknown()
+	unknown, err := cfg.Process()
+	if err != nil {
 		return err
 	}
 
@@ -142,6 +152,19 @@ func (bl *DNSBL) readListCfg(node config.Node) error {
 			return err
 		}
 		listCfg.Responses = append(listCfg.Responses, *ipNet)
+	}
+
+	// Parse response blocks
+	for _, child := range unknown {
+		if child.Name == "response" {
+			rule, err := parseResponseRule(child)
+			if err != nil {
+				return err
+			}
+			listCfg.ResponseRules = append(listCfg.ResponseRules, rule)
+		} else {
+			return config.NodeErr(child, "unknown directive: %s", child.Name)
+		}
 	}
 
 	for _, zone := range append([]string{node.Name}, node.Args...) {
@@ -171,6 +194,44 @@ func (bl *DNSBL) readListCfg(node config.Node) error {
 	}
 
 	return nil
+}
+
+func parseResponseRule(node config.Node) (ResponseRule, error) {
+	var rule ResponseRule
+
+	if len(node.Args) == 0 {
+		return rule, config.NodeErr(node, "response block requires at least one IP address or CIDR as argument")
+	}
+
+	// Parse IP addresses/CIDRs from arguments
+	for _, arg := range node.Args {
+		// If there is no / - it is a plain IP address, append '/32' or '/128'
+		resp := arg
+		if !strings.Contains(resp, "/") {
+			// Check if it's IPv6 to determine the mask
+			if strings.Contains(resp, ":") {
+				resp += "/128"
+			} else {
+				resp += "/32"
+			}
+		}
+
+		_, ipNet, err := net.ParseCIDR(resp)
+		if err != nil {
+			return rule, config.NodeErr(node, "invalid IP address or CIDR: %s: %v", arg, err)
+		}
+		rule.Networks = append(rule.Networks, *ipNet)
+	}
+
+	// Parse directives within the response block
+	cfg := config.NewMap(nil, node)
+	cfg.Int("score", false, true, 0, &rule.Score)
+	cfg.String("message", false, false, "", &rule.Message)
+	if _, err := cfg.Process(); err != nil {
+		return rule, err
+	}
+
+	return rule, nil
 }
 
 func (bl *DNSBL) testList(listCfg List) {
@@ -298,6 +359,7 @@ func (bl *DNSBL) checkLists(ctx context.Context, ip net.IP, ehlo, mailFrom strin
 		score    int
 		listedOn []string
 		reasons  []string
+		messages []string
 	)
 
 	for _, list := range bl.bls {
@@ -313,7 +375,18 @@ func (bl *DNSBL) checkLists(ctx context.Context, ip net.IP, ehlo, mailFrom strin
 				defer lck.Unlock()
 				listedOn = append(listedOn, listErr.List)
 				reasons = append(reasons, listErr.Reason)
-				score += list.ScoreAdj
+				
+				// Use score from ListedErr if set (new behavior), otherwise use legacy ScoreAdj
+				if listErr.Score != 0 {
+					score += listErr.Score
+				} else {
+					score += list.ScoreAdj
+				}
+				
+				// Collect custom messages if available
+				if listErr.Message != "" {
+					messages = append(messages, listErr.Message)
+				}
 			}
 			return nil
 		})
@@ -334,13 +407,19 @@ func (bl *DNSBL) checkLists(ctx context.Context, ip net.IP, ehlo, mailFrom strin
 		}
 	}
 
+	// Use custom message if available, otherwise use default
+	message := "Client identity is listed in the used DNSBL"
+	if len(messages) > 0 {
+		message = strings.Join(messages, "; ")
+	}
+
 	if score >= bl.rejectThres {
 		return module.CheckResult{
 			Reject: true,
 			Reason: &exterrors.SMTPError{
 				Code:         554,
 				EnhancedCode: exterrors.EnhancedCode{5, 7, 0},
-				Message:      "Client identity is listed in the used DNSBL",
+				Message:      message,
 				Err:          err,
 				CheckName:    "dnsbl",
 			},
@@ -352,7 +431,7 @@ func (bl *DNSBL) checkLists(ctx context.Context, ip net.IP, ehlo, mailFrom strin
 			Reason: &exterrors.SMTPError{
 				Code:         554,
 				EnhancedCode: exterrors.EnhancedCode{5, 7, 0},
-				Message:      "Client identity is listed in the used DNSBL",
+				Message:      message,
 				Err:          err,
 				CheckName:    "dnsbl",
 			},

--- a/internal/check/dnsbl/dnsbl_test.go
+++ b/internal/check/dnsbl/dnsbl_test.go
@@ -490,4 +490,3 @@ func TestCheckListsWithResponseRules(t *testing.T) {
 		},
 	}, net.IPv4(1, 2, 3, 4), "mx.example.com", "foo@example.com", false, true) // 5 + 3 = 8, quarantine but not reject
 }
-

--- a/internal/check/dnsbl/dnsbl_test.go
+++ b/internal/check/dnsbl/dnsbl_test.go
@@ -211,3 +211,283 @@ func TestCheckLists(t *testing.T) {
 		true, false,
 	)
 }
+
+func TestCheckIPWithResponseRules(t *testing.T) {
+	test := func(zones map[string]mockdns.Zone, cfg List, ip net.IP, expectedErr error) {
+		t.Helper()
+		resolver := mockdns.Resolver{Zones: zones}
+		err := checkIP(context.Background(), &resolver, cfg, ip)
+		if expectedErr == nil {
+			if err != nil {
+				t.Errorf("expected no error, got '%#v'", err)
+			}
+		} else {
+			if err == nil {
+				t.Errorf("expected err to be '%#v', got nil", expectedErr)
+			} else {
+				expectedLE, okExpected := expectedErr.(ListedErr)
+				actualLE, okActual := err.(ListedErr)
+				if !okExpected || !okActual {
+					t.Errorf("expected err to be '%#v', got '%#v'", expectedErr, err)
+				} else {
+					if expectedLE.Identity != actualLE.Identity ||
+						expectedLE.List != actualLE.List ||
+						expectedLE.Score != actualLE.Score ||
+						expectedLE.Message != actualLE.Message {
+						t.Errorf("expected err to be '%#v', got '%#v'", expectedErr, err)
+					}
+				}
+			}
+		}
+	}
+
+	// Test single response code with score and message
+	test(map[string]mockdns.Zone{
+		"4.3.2.1.example.org.": {
+			A: []string{"127.0.0.2"},
+		},
+	}, List{
+		Zone:       "example.org",
+		ClientIPv4: true,
+		ResponseRules: []ResponseRule{
+			{
+				Networks: []net.IPNet{
+					{IP: net.IPv4(127, 0, 0, 2), Mask: net.IPv4Mask(255, 255, 255, 255)},
+				},
+				Score:   10,
+				Message: "Listed in SBL",
+			},
+		},
+	}, net.IPv4(1, 2, 3, 4), ListedErr{
+		Identity: "1.2.3.4",
+		List:     "example.org",
+		Score:    10,
+		Message:  "Listed in SBL",
+	})
+
+	// Test multiple response codes with different scores - scores should sum
+	test(map[string]mockdns.Zone{
+		"4.3.2.1.example.org.": {
+			A: []string{"127.0.0.2", "127.0.0.11"},
+		},
+	}, List{
+		Zone:       "example.org",
+		ClientIPv4: true,
+		ResponseRules: []ResponseRule{
+			{
+				Networks: []net.IPNet{
+					{IP: net.IPv4(127, 0, 0, 2), Mask: net.IPv4Mask(255, 255, 255, 255)},
+					{IP: net.IPv4(127, 0, 0, 3), Mask: net.IPv4Mask(255, 255, 255, 255)},
+				},
+				Score:   10,
+				Message: "Listed in SBL",
+			},
+			{
+				Networks: []net.IPNet{
+					{IP: net.IPv4(127, 0, 0, 10), Mask: net.IPv4Mask(255, 255, 255, 255)},
+					{IP: net.IPv4(127, 0, 0, 11), Mask: net.IPv4Mask(255, 255, 255, 255)},
+				},
+				Score:   5,
+				Message: "Listed in PBL",
+			},
+		},
+	}, net.IPv4(1, 2, 3, 4), ListedErr{
+		Identity: "1.2.3.4",
+		List:     "example.org",
+		Score:    15, // 10 + 5
+		Message:  "Listed in SBL",
+	})
+
+	// Test response code that doesn't match any rule - should return nil
+	test(map[string]mockdns.Zone{
+		"4.3.2.1.example.org.": {
+			A: []string{"127.0.0.99"},
+		},
+	}, List{
+		Zone:       "example.org",
+		ClientIPv4: true,
+		ResponseRules: []ResponseRule{
+			{
+				Networks: []net.IPNet{
+					{IP: net.IPv4(127, 0, 0, 2), Mask: net.IPv4Mask(255, 255, 255, 255)},
+				},
+				Score:   10,
+				Message: "Listed in SBL",
+			},
+		},
+	}, net.IPv4(1, 2, 3, 4), nil)
+
+	// Test low severity only - should get score 5
+	test(map[string]mockdns.Zone{
+		"4.3.2.1.example.org.": {
+			A: []string{"127.0.0.10"},
+		},
+	}, List{
+		Zone:       "example.org",
+		ClientIPv4: true,
+		ResponseRules: []ResponseRule{
+			{
+				Networks: []net.IPNet{
+					{IP: net.IPv4(127, 0, 0, 2), Mask: net.IPv4Mask(255, 255, 255, 255)},
+				},
+				Score:   10,
+				Message: "Listed in SBL",
+			},
+			{
+				Networks: []net.IPNet{
+					{IP: net.IPv4(127, 0, 0, 10), Mask: net.IPv4Mask(255, 255, 255, 255)},
+				},
+				Score:   5,
+				Message: "Listed in PBL",
+			},
+		},
+	}, net.IPv4(1, 2, 3, 4), ListedErr{
+		Identity: "1.2.3.4",
+		List:     "example.org",
+		Score:    5,
+		Message:  "Listed in PBL",
+	})
+
+	// Test high severity - should get score 10
+	test(map[string]mockdns.Zone{
+		"4.3.2.1.example.org.": {
+			A: []string{"127.0.0.2"},
+		},
+	}, List{
+		Zone:       "example.org",
+		ClientIPv4: true,
+		ResponseRules: []ResponseRule{
+			{
+				Networks: []net.IPNet{
+					{IP: net.IPv4(127, 0, 0, 2), Mask: net.IPv4Mask(255, 255, 255, 255)},
+				},
+				Score:   10,
+				Message: "Listed in SBL",
+			},
+		},
+	}, net.IPv4(1, 2, 3, 4), ListedErr{
+		Identity: "1.2.3.4",
+		List:     "example.org",
+		Score:    10,
+		Message:  "Listed in SBL",
+	})
+}
+
+func TestCheckListsWithResponseRules(t *testing.T) {
+	test := func(zones map[string]mockdns.Zone, bls []List, ip net.IP, ehlo, mailFrom string, reject, quarantine bool) {
+		mod := &DNSBL{
+			bls:             bls,
+			resolver:        &mockdns.Resolver{Zones: zones},
+			log:             testutils.Logger(t, "dnsbl"),
+			quarantineThres: 5,
+			rejectThres:     10,
+		}
+		result := mod.checkLists(context.Background(), ip, ehlo, mailFrom)
+
+		if result.Reject && !reject {
+			t.Errorf("Expected message to not be rejected")
+		}
+		if !result.Reject && reject {
+			t.Errorf("Expected message to be rejected")
+		}
+		if result.Quarantine && !quarantine {
+			t.Errorf("Expected message to not be quarantined")
+		}
+		if !result.Quarantine && quarantine {
+			t.Errorf("Expected message to be quarantined")
+		}
+	}
+
+	// Test: Only low-severity code returned -> quarantine but not reject
+	test(map[string]mockdns.Zone{
+		"4.3.2.1.zen.example.org.": {
+			A: []string{"127.0.0.11"},
+		},
+	}, []List{
+		{
+			Zone:       "zen.example.org",
+			ClientIPv4: true,
+			ResponseRules: []ResponseRule{
+				{
+					Networks: []net.IPNet{
+						{IP: net.IPv4(127, 0, 0, 2), Mask: net.IPv4Mask(255, 255, 255, 255)},
+					},
+					Score:   10,
+					Message: "Listed in SBL",
+				},
+				{
+					Networks: []net.IPNet{
+						{IP: net.IPv4(127, 0, 0, 10), Mask: net.IPv4Mask(255, 255, 255, 255)},
+						{IP: net.IPv4(127, 0, 0, 11), Mask: net.IPv4Mask(255, 255, 255, 255)},
+					},
+					Score:   5,
+					Message: "Listed in PBL",
+				},
+			},
+		},
+	}, net.IPv4(1, 2, 3, 4), "mx.example.com", "foo@example.com", false, true)
+
+	// Test: High-severity code returned -> reject
+	test(map[string]mockdns.Zone{
+		"4.3.2.1.zen.example.org.": {
+			A: []string{"127.0.0.2"},
+		},
+	}, []List{
+		{
+			Zone:       "zen.example.org",
+			ClientIPv4: true,
+			ResponseRules: []ResponseRule{
+				{
+					Networks: []net.IPNet{
+						{IP: net.IPv4(127, 0, 0, 2), Mask: net.IPv4Mask(255, 255, 255, 255)},
+					},
+					Score:   10,
+					Message: "Listed in SBL",
+				},
+			},
+		},
+	}, net.IPv4(1, 2, 3, 4), "mx.example.com", "foo@example.com", true, false)
+
+	// Test: Legacy configuration without response blocks -> existing behavior preserved
+	test(map[string]mockdns.Zone{
+		"4.3.2.1.example.org.": {
+			A: []string{"127.0.0.1"},
+		},
+	}, []List{
+		{
+			Zone:       "example.org",
+			ClientIPv4: true,
+			ScoreAdj:   10,
+		},
+	}, net.IPv4(1, 2, 3, 4), "mx.example.com", "foo@example.com", true, false)
+
+	// Test: Mixed configuration (some lists with response blocks, some without) -> both work correctly
+	test(map[string]mockdns.Zone{
+		"4.3.2.1.zen.example.org.": {
+			A: []string{"127.0.0.11"},
+		},
+		"4.3.2.1.legacy.example.org.": {
+			A: []string{"127.0.0.1"},
+		},
+	}, []List{
+		{
+			Zone:       "zen.example.org",
+			ClientIPv4: true,
+			ResponseRules: []ResponseRule{
+				{
+					Networks: []net.IPNet{
+						{IP: net.IPv4(127, 0, 0, 11), Mask: net.IPv4Mask(255, 255, 255, 255)},
+					},
+					Score:   5,
+					Message: "Listed in PBL",
+				},
+			},
+		},
+		{
+			Zone:       "legacy.example.org",
+			ClientIPv4: true,
+			ScoreAdj:   3,
+		},
+	}, net.IPv4(1, 2, 3, 4), "mx.example.com", "foo@example.com", false, true) // 5 + 3 = 8, quarantine but not reject
+}
+


### PR DESCRIPTION
## Summary

This PR adds support for per-response-code scoring in DNSBL checks, allowing administrators to assign different scores and custom rejection messages based on specific DNSBL return codes.  This enables efficient use of combined DNSBLs like Spamhaus ZEN with granular control. 

## Problem

Combined DNSBLs like Spamhaus ZEN (`zen.spamhaus.org`) return different response codes for different listing types: 

| Response Code | List | Severity |
|---------------|------|----------|
| `127.0.0.2`, `127.0.0.3` | SBL (known spam sources) | High |
| `127.0.0.4`-`127.0.0.7` | XBL (exploited/compromised hosts) | High |
| `127.0.0.10`, `127.0.0.11` | PBL (dynamic IPs) | Lower |

Currently, Maddy: 
1. Counts any response within `127.0.0.1/24` as a single "hit"
2. Applies the same score regardless of which specific code was returned
3. Cannot provide response-code-specific rejection messages
4. If multiple codes are returned, they all count as one hit with one score

Users who want different scores for different listing types must query separate lists (`sbl.spamhaus.org`, `xbl.spamhaus.org`, `pbl.spamhaus.org`), resulting in **3 DNS queries instead of 1**.

Reference: https://docs.spamhaus.com/datasets/docs/source/40-real-world-usage/PublicMirrors/MTAs/020-Postfix. html

## Solution

Add a new `response` configuration block that allows per-response-code scoring and custom messages:

```
check.dnsbl {
    reject_threshold 10
    quarantine_threshold 5

    zen.spamhaus.org {
        client_ipv4 yes
        client_ipv6 yes
        
        # SBL - Spamhaus Block List (known spam sources)
        response 127.0.0.2 127.0.0.3 {
            score 10
            message "Listed in Spamhaus SBL. See https://check.spamhaus.org/"
        }
        
        # XBL - Exploits Block List (compromised hosts)
        response 127.0.0.4 127.0.0.5 127.0.0.6 127.0.0.7 {
            score 10
            message "Listed in Spamhaus XBL. See https://check.spamhaus.org/"
        }
        
        # PBL - Policy Block List (dynamic IPs)
        response 127.0.0.10 127.0.0.11 {
            score 5
            message "Listed in Spamhaus PBL. See https://check.spamhaus.org/"
        }
    }
}
```

When multiple response codes are returned (e.g., `127.0.0.2` and `127.0.0.11`), their scores are **summed** (10 + 5 = 15 in this example).

## Changes

### Data Structures
- Added `ResponseRule` struct with `Networks`, `Score`, and `Message` fields
- Extended `List` struct with `ResponseRules []ResponseRule`
- Extended `ListedErr` with `Score` and `Message` fields

### Core Logic
- `checkIP()` now matches response codes against rules and sums scores
- `checkLists()` uses `ListedErr.Score` when set, falls back to legacy `ScoreAdj`
- `ListedErr.Fields()` uses custom message when available

### Configuration
- Added `parseResponseRule()` to parse new `response` blocks
- Updated `readListCfg()` to handle response blocks via `AllowUnknown()`

### Backwards Compatibility
- Legacy `responses` + `score` configuration works unchanged
- New behavior only activates when `ResponseRules` is configured

## Benefits

| Feature | Before | After |
|---------|--------|-------|
| DNS queries for ZEN | 1 (codes ignored) | 1 (codes interpreted) |
| Per-code scoring | ❌ | ✅ |
| Custom rejection messages | ❌ | ✅ |
| Backwards compatible | N/A | ✅ |

## Testing

- Added test cases for multiple return codes with different scores
- Added test cases for low-severity vs high-severity responses
- Verified legacy configuration behavior is preserved