### PR TITLE
Make reject and soft reject have configurable action in rspamd module.

### DIFF
--- a/dist/vim/syntax/maddy-conf.vim
+++ b/dist/vim/syntax/maddy-conf.vim
@@ -183,6 +183,7 @@ syn keyword maddyModDir
 	\ quarantine_threshold
 	\ read_timeout
 	\ reject_threshold
+	\ reject_action
 	\ relaxed_requiretls
 	\ required_fields
 	\ require_sender_match
@@ -198,6 +199,7 @@ syn keyword maddyModDir
 	\ sig_expiry
 	\ sign_fields
 	\ sign_subdomains
+	\ soft_reject_action
 	\ softfail_action
 	\ SOME_action
 	\ source

--- a/docs/reference/checks/rspamd.md
+++ b/docs/reference/checks/rspamd.md
@@ -14,6 +14,8 @@ check.rspamd {
 	error_resp_action ignore
 	add_header_action quarantine
 	rewrite_subj_action quarantine
+	reject_action reject
+	soft_reject_action reject
 	flags pass_all
 }
 
@@ -87,6 +89,20 @@ Default: `quarantine`
 Action to take when rspamd requests to "rewrite subject".
 
 X-Spam-Flag and X-Spam-Score are added to the header irregardless of value.
+
+---
+
+### reject_action _action_
+Default: `reject`
+
+Action to take when rspamd requests to "reject".
+
+---
+
+### soft_reject_action _action_
+Default: `reject`
+
+Action to take when rspamd requests to "soft reject".
 
 ---
 

--- a/internal/check/rspamd/rspamd.go
+++ b/internal/check/rspamd/rspamd.go
@@ -57,6 +57,8 @@ type Check struct {
 	errorRespAction   modconfig.FailAction
 	addHdrAction      modconfig.FailAction
 	rewriteSubjAction modconfig.FailAction
+	rejectAction      modconfig.FailAction
+	softRejectAction  modconfig.FailAction
 
 	client *http.Client
 }
@@ -117,6 +119,15 @@ func (c *Check) Configure(inlineArgs []string, cfg *config.Map) error {
 		func() (interface{}, error) {
 			return modconfig.FailAction{Quarantine: true}, nil
 		}, modconfig.FailActionDirective, &c.rewriteSubjAction)
+	cfg.Custom("reject_action", false, false,
+		func() (interface{}, error) {
+			return modconfig.FailAction{Reject: true}, nil
+		}, modconfig.FailActionDirective, &c.rejectAction)
+	cfg.Custom("soft_reject_action", false, false,
+		func() (interface{}, error) {
+			return modconfig.FailAction{Reject: true}, nil
+		}, modconfig.FailActionDirective, &c.softRejectAction)
+
 	cfg.StringList("flags", false, false, []string{"pass_all"}, &flags)
 	if _, err := cfg.Process(); err != nil {
 		return err
@@ -320,7 +331,7 @@ func (s *state) CheckBody(ctx context.Context, hdr textproto.Header, body buffer
 			Header: hdrAdd,
 		})
 	case "soft reject":
-		return module.CheckResult{
+		return s.c.softRejectAction.Apply(module.CheckResult{
 			Reject: true,
 			Reason: &exterrors.SMTPError{
 				Code:         450,
@@ -329,9 +340,9 @@ func (s *state) CheckBody(ctx context.Context, hdr textproto.Header, body buffer
 				CheckName:    modName,
 				Misc:         map[string]interface{}{"action": "soft reject"},
 			},
-		}
+		})
 	case "reject":
-		return module.CheckResult{
+		return s.c.rejectAction.Apply(module.CheckResult{
 			Reject: true,
 			Reason: &exterrors.SMTPError{
 				Code:         550,
@@ -340,7 +351,7 @@ func (s *state) CheckBody(ctx context.Context, hdr textproto.Header, body buffer
 				CheckName:    modName,
 				Misc:         map[string]interface{}{"action": "reject"},
 			},
-		}
+		})
 	}
 
 	s.log.Msg("unhandled action", "action", respData.Action)


### PR DESCRIPTION
So I originally make issue #820, but I decided to do it myself.
In the rspamd check it adds 2 new action config: `reject_action` and `soft_reject_action`.
Default is kept as is, so nothing breaks or changes for anyone else.
Please notify if I do something wrong, it looks correct to me atleast.