### PR TITLE
rspamd: fix panic on unspecified tls_client

### DIFF
--- a/internal/check/rspamd/rspamd.go
+++ b/internal/check/rspamd/rspamd.go
@@ -97,7 +97,7 @@ func (c *Check) Configure(inlineArgs []string, cfg *config.Map) error {
 	)
 
 	cfg.Custom("tls_client", true, false, func() (interface{}, error) {
-		return tls.Config{}, nil
+		return &tls.Config{}, nil
 	}, tls2.TLSClientBlock, &tlsConfig)
 	cfg.String("api_path", false, false, c.apiPath, &c.apiPath)
 	cfg.String("settings_id", false, false, "", &c.settingsID)


### PR DESCRIPTION
Upgraded maddy on my server from v0.8.2 -> v0.9.1 and it immediately crashed on startup with following error:

```
panic: reflect.Set: value of type tls.Config is not assignable to type *tls.Config
```

Tried this patch on my setup and it resolved the issue. I suppose it is connected to https://github.com/foxcpp/maddy/commit/a90af91150296e9d29c991a2bbb1de0b6e6e51b5.