### PR TITLE
smtp: add LOGIN SASL auth directive

### DIFF
--- a/internal/target/smtp/sasl.go
+++ b/internal/target/smtp/sasl.go
@@ -57,12 +57,18 @@ func saslAuthDirective(_ *config.Map, node config.Node) (interface{}, error) {
 			}
 			return sasl.NewPlainClient("", msgMeta.Conn.AuthUser, msgMeta.Conn.AuthPassword), nil
 		}, nil
-	case "plain":
+	case "plain", "login":
 		if len(node.Args) != 3 {
 			return nil, config.NodeErr(node, "two additional arguments are required (username, password)")
 		}
 		return func(*module.MsgMetadata) (sasl.Client, error) {
-			return sasl.NewPlainClient("", node.Args[1], node.Args[2]), nil
+			if node.Args[0] == "plain" {
+				return sasl.NewPlainClient("", node.Args[1], node.Args[2]), nil
+			}
+			if node.Args[0] == "login" {
+				return sasl.NewLoginClient(node.Args[1], node.Args[2]), nil
+			}
+			return nil, config.NodeErr(node, "unknown authentication mechanism: %s", node.Args[0])
 		}, nil
 	case "external":
 		if len(node.Args) > 1 {

--- a/internal/target/smtp/sasl_test.go
+++ b/internal/target/smtp/sasl_test.go
@@ -101,6 +101,23 @@ func TestSASL_Plain_AuthFail(t *testing.T) {
 	}
 }
 
+func TestSASL_Login_Directive(t *testing.T) {
+	factory := testSaslFactory(t, "login", "test", "testpass")
+	client, err := factory(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mech, _, err := client.Start()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if mech != "LOGIN" {
+		t.Fatalf("expected LOGIN mechanism, got %q", mech)
+	}
+}
+
 func TestSASL_Forward(t *testing.T) {
 	be, srv := testutils.SMTPServer(t, "127.0.0.1:"+testPort)
 	defer func() {


### PR DESCRIPTION
## Summary
Add support for a `login` SASL authentication directive in the SMTP target.

## Changes
- Extend the SMTP SASL directive parser to accept `login` alongside `plain`
- Use `sasl.NewLoginClient(...)` when `login` is selected
- Add a focused unit test covering the LOGIN directive and mechanism name

## Why
Some SMTP relays only support the `LOGIN` authentication mechanism and reject `PLAIN`. This makes Maddy usable with those upstream relays without requiring downstream patching or custom images.

## Validation
- Patch applies cleanly on current upstream
- `go test ./internal/target/smtp -run TestSASL_Login_Directive -count=1 -timeout 90s`

## Notes
This is a narrow change limited to the SMTP target SASL directive path and preserves existing `plain` behavior.