### PR TITLE
fix: check for nil Out in Logger on Close()

### DIFF
--- a/framework/log/log.go
+++ b/framework/log/log.go
@@ -205,6 +205,15 @@ func (l *Logger) Write(s []byte) (int, error) {
 	return len(s), nil
 }
 
+// Close closes underlying output in Out.
+func (l *Logger) Close() error {
+	if l.Out == nil {
+		return nil
+	}
+
+	return l.Out.Close()
+}
+
 // DebugWriter returns a writer that will act like Logger.Write
 // but will use debug flag on messages. If Logger.Debug is false,
 // Write method of returned object will be no-op.

--- a/maddy.go
+++ b/maddy.go
@@ -450,7 +450,7 @@ func moduleMain(configPath string) error {
 	c.DefaultLogger.Msg("server stopped")
 
 	if c.DefaultLogger.Out != nil {
-		if err := c.DefaultLogger.Out.Close(); err != nil {
+		if err := c.DefaultLogger.Close(); err != nil {
 			log.DefaultLogger.Error("failed to close output logger", err)
 		}
 	}
@@ -517,7 +517,7 @@ func moduleReload(oldContainer *container.C, configPath string, asyncStopWg *syn
 			oldContainer.DefaultLogger.Error("moduleStop failed", err)
 		}
 		oldContainer.DefaultLogger.Msg("old server stopped")
-		if err := oldContainer.DefaultLogger.Out.Close(); err != nil {
+		if err := oldContainer.DefaultLogger.Close(); err != nil {
 			newContainer.DefaultLogger.Error("failed to close old server log", err)
 		}
 


### PR DESCRIPTION
* add Logger.Close(), which safely closes underlying Out
* fixes #846