### PR TITLE
fix(systemd): report READY=1 after reload

### DIFF
--- a/maddy.go
+++ b/maddy.go
@@ -521,7 +521,7 @@ func moduleReload(oldContainer *container.C, configPath string, asyncStopWg *syn
 			newContainer.DefaultLogger.Error("failed to close old server log", err)
 		}
 
-		systemdStatus(SDReloading, "Configuration running.")
+		systemdStatus(SDReady, "Configuration running.")
 	}()
 
 	return newContainer


### PR DESCRIPTION
SystemD would report maddy in "reloading (reload-notify)" state even after successful reload. It should send "READY=1" after finishing the reload.