### PR TITLE
modify/dkim: Do not oversign Sender header filed by default

### DIFF
--- a/internal/modify/dkim/dkim.go
+++ b/internal/modify/dkim/dkim.go
@@ -50,7 +50,6 @@ var (
 	oversignDefault = []string{
 		// Directly visible to the user.
 		"Subject",
-		"Sender",
 		"To",
 		"Cc",
 		"From",
@@ -80,6 +79,7 @@ var (
 		"List-Post",
 		"List-Owner",
 		"List-Archive",
+		"Sender",
 
 		// Not oversigned since it can be prepended by intermediate relays.
 		"Resent-To",


### PR DESCRIPTION
fix: #768