### PR TITLE
limits/limiters: fix panic when bucket set is full

### DIFF
--- a/internal/limits/limiters/bucket.go
+++ b/internal/limits/limiters/bucket.go
@@ -20,9 +20,12 @@ package limiters
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 )
+
+var ErrBucketSetFull = errors.New("limiters: Bucket set is full")
 
 // BucketSet combines a group of Ls into a single key-indexed structure.
 // Basically, each unique key gets its own counter. The main use case for
@@ -125,6 +128,9 @@ func (r *BucketSet) Take(key string) bool {
 	}
 
 	bucket := r.take(key)
+	for bucket == nil {
+		return false
+	}
 	return bucket.Take()
 }
 
@@ -149,5 +155,9 @@ func (r *BucketSet) TakeContext(ctx context.Context, key string) error {
 	}
 
 	bucket := r.take(key)
+	if bucket == nil {
+		return ErrBucketSetFull
+	}
+
 	return bucket.TakeContext(ctx)
 }


### PR DESCRIPTION
fix: #857 

There is a comment in the code: 
https://github.com/foxcpp/maddy/blob/e42741c7577746a474a45a818d554d578f4f853d/internal/limits/limits.go#L110-L120

However, the maximum number of SMTP recipients is only limited per single connection.   If more than 20,000 recipients are obtained through multiple connections within one minute, the bucket may also become full.

I considered whether should wait for the old limiter to be reaped. But with heavy load when the bucket is full, I think blocking the process is not a good idea.